### PR TITLE
MGMT-16618: Make hive APIs work

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -15,8 +15,8 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: openshift.io
-  group: relocation
+  domain: hive.openshift.io
+  group: extensions
   kind: ImageClusterInstall
   path: github.com/openshift/cluster-relocation-service/api/v1alpha1
   version: v1alpha1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the relocation v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the extensions v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=relocation.openshift.io
+// +groupName=extensions.hive.openshift.io
 package v1alpha1
 
 import (
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	Group   = "relocation.openshift.io"
+	Group   = "extensions.hive.openshift.io"
 	Version = "v1alpha1"
 )
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	relocationv1alpha1 "github.com/openshift/cluster-relocation-service/api/v1alpha1"
+	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
 	"github.com/openshift/cluster-relocation-service/controllers"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/sirupsen/logrus"
@@ -50,7 +50,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(relocationv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(bmh_v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(hivev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
@@ -120,7 +120,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageClusterInstall")
 		os.Exit(1)
 	}
-	if err = (&relocationv1alpha1.ImageClusterInstall{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&v1alpha1.ImageClusterInstall{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ImageClusterInstall")
 		os.Exit(1)
 	}

--- a/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: imageclusterinstalls.relocation.openshift.io
+  name: imageclusterinstalls.extensions.hive.openshift.io
 spec:
-  group: relocation.openshift.io
+  group: extensions.hive.openshift.io
   names:
     kind: ImageClusterInstall
     listKind: ImageClusterInstallList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
 - bases/relocation.openshift.io_imageclusterinstalls.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
+patchesStrategicMerge:
+- patches/hive_contract_label.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/relocation.openshift.io_imageclusterinstalls.yaml
+- bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/hive_contract_label.yaml
+++ b/config/crd/patches/hive_contract_label.yaml
@@ -3,4 +3,4 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     contracts.hive.openshift.io/clusterinstall: "true"
-  name: imageclusterinstalls.relocation.openshift.io
+  name: imageclusterinstalls.extensions.hive.openshift.io

--- a/config/crd/patches/hive_contract_label.yaml
+++ b/config/crd/patches/hive_contract_label.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    contracts.hive.openshift.io/clusterinstall: "true"
+  name: imageclusterinstalls.relocation.openshift.io

--- a/config/rbac/imageclusterinstall_editor_role.yaml
+++ b/config/rbac/imageclusterinstall_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: imageclusterinstall-editor
 rules:
 - apiGroups:
-  - relocation.openshift.io
+  - extensions.hive.openshift.io
   resources:
   - imageclusterinstalls
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - relocation.openshift.io
+  - extensions.hive.openshift.io
   resources:
   - imageclusterinstalls/status
   verbs:

--- a/config/rbac/imageclusterinstall_viewer_role.yaml
+++ b/config/rbac/imageclusterinstall_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: imageclusterinstall-viewer
 rules:
 - apiGroups:
-  - relocation.openshift.io
+  - extensions.hive.openshift.io
   resources:
   - imageclusterinstalls
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - relocation.openshift.io
+  - extensions.hive.openshift.io
   resources:
   - imageclusterinstalls/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments
@@ -33,29 +59,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - relocation.openshift.io
-  resources:
-  - imageclusterinstalls
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - relocation.openshift.io
-  resources:
-  - imageclusterinstalls/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - relocation.openshift.io
-  resources:
-  - imageclusterinstalls/status
-  verbs:
-  - get
-  - patch
-  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterimagesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts

--- a/config/samples/extensions_v1alpha1_imageclusterinstall.yaml
+++ b/config/samples/extensions_v1alpha1_imageclusterinstall.yaml
@@ -1,4 +1,4 @@
-apiVersion: relocation.openshift.io/v1alpha1
+apiVersion: extensions.hive.openshift.io/v1alpha1
 kind: ImageClusterInstall
 metadata:
   name: imageclusterinstall

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-- relocation_v1alpha1_imageclusterinstall.yaml
+- extensions_v1alpha1_imageclusterinstall.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: imageclusterinstalls.relocation.openshift.io
+  name: imageclusterinstalls.extensions.hive.openshift.io
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
@@ -12,12 +12,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-relocation-openshift-io-v1alpha1-imageclusterinstall
+      path: /validate-extensions-hive-openshift-io-v1alpha1-imageclusterinstall
   failurePolicy: Fail
-  name: imageclusterinstalls.relocation.openshift.io
+  name: imageclusterinstalls.extensions.hive.openshift.io
   rules:
   - apiGroups:
-    - relocation.openshift.io
+    - extensions.hive.openshift.io
     apiVersions:
     - v1alpha1
     operations:

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -87,6 +87,7 @@ const (
 //+kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls/finalizers,verbs=update
 //+kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch
 
 func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithFields(logrus.Fields{"name": req.Name, "namespace": req.Namespace})

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -18,7 +18,7 @@ import (
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift-kni/lifecycle-agent/ibu-imager/clusterinfo"
-	relocationv1alpha1 "github.com/openshift/cluster-relocation-service/api/v1alpha1"
+	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/sirupsen/logrus"
 
@@ -34,14 +34,14 @@ var _ = Describe("Reconcile", func() {
 		ctx                     = context.Background()
 		clusterInstallName      = "test-cluster"
 		clusterInstallNamespace = "test-namespace"
-		clusterInstall          *relocationv1alpha1.ImageClusterInstall
+		clusterInstall          *v1alpha1.ImageClusterInstall
 		clusterDeployment       *hivev1.ClusterDeployment
 	)
 
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().
 			WithScheme(scheme.Scheme).
-			WithStatusSubresource(&relocationv1alpha1.ImageClusterInstall{}).
+			WithStatusSubresource(&v1alpha1.ImageClusterInstall{}).
 			Build()
 		var err error
 		dataDir, err = os.MkdirTemp("", "imageclusterinstall_controller_test_data")
@@ -71,13 +71,13 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, imageSet)).To(Succeed())
 
-		clusterInstall = &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall = &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       clusterInstallName,
 				Namespace:  clusterInstallNamespace,
 				Finalizers: []string{clusterInstallFinalizerName},
 			},
-			Spec: relocationv1alpha1.ImageClusterInstallSpec{
+			Spec: v1alpha1.ImageClusterInstallSpec{
 				ImageSetRef: hivev1.ClusterImageSetReference{
 					Name: imageSet.Name,
 				},
@@ -325,7 +325,7 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      bmh.Name,
 			Namespace: bmh.Namespace,
 		}
@@ -368,7 +368,7 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      bmh.Name,
 			Namespace: bmh.Namespace,
 		}
@@ -415,7 +415,7 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      bmh.Name,
 			Namespace: bmh.Namespace,
 		}
@@ -476,11 +476,11 @@ var _ = Describe("Reconcile", func() {
 		Expect(res).To(Equal(ctrl.Result{}))
 
 		Expect(c.Get(ctx, key, clusterInstall)).To(Succeed())
-		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, relocationv1alpha1.ImageReadyCondition)
+		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, v1alpha1.ImageReadyCondition)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-		Expect(cond.Reason).To(Equal(relocationv1alpha1.ImageReadyReason))
-		Expect(cond.Message).To(Equal(relocationv1alpha1.ImageReadyMessage))
+		Expect(cond.Reason).To(Equal(v1alpha1.ImageReadyReason))
+		Expect(cond.Message).To(Equal(v1alpha1.ImageReadyMessage))
 	})
 
 	It("sets the host configured condition when the host can be configured", func() {
@@ -497,7 +497,7 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      bmh.Name,
 			Namespace: bmh.Namespace,
 		}
@@ -513,15 +513,15 @@ var _ = Describe("Reconcile", func() {
 		Expect(res).To(Equal(ctrl.Result{}))
 
 		Expect(c.Get(ctx, key, clusterInstall)).To(Succeed())
-		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, relocationv1alpha1.HostConfiguredCondition)
+		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, v1alpha1.HostConfiguredCondition)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-		Expect(cond.Reason).To(Equal(relocationv1alpha1.HostConfiguraionSucceededReason))
-		Expect(cond.Message).To(Equal(relocationv1alpha1.HostConfigurationSucceededMessage))
+		Expect(cond.Reason).To(Equal(v1alpha1.HostConfiguraionSucceededReason))
+		Expect(cond.Message).To(Equal(v1alpha1.HostConfigurationSucceededMessage))
 	})
 
 	It("sets the host configured condition to false when the host is missing", func() {
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      "test-bmh",
 			Namespace: "test-bmh-namespace",
 		}
@@ -537,10 +537,10 @@ var _ = Describe("Reconcile", func() {
 		Expect(res).To(Equal(ctrl.Result{}))
 
 		Expect(c.Get(ctx, key, clusterInstall)).To(Succeed())
-		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, relocationv1alpha1.HostConfiguredCondition)
+		cond := meta.FindStatusCondition(clusterInstall.Status.ConfigConditions, v1alpha1.HostConfiguredCondition)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-		Expect(cond.Reason).To(Equal(relocationv1alpha1.HostConfiguraionFailedReason))
+		Expect(cond.Reason).To(Equal(v1alpha1.HostConfiguraionFailedReason))
 	})
 
 	It("removes the image from a BMH when the reference is removed", func() {
@@ -560,8 +560,8 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall.Status = relocationv1alpha1.ImageClusterInstallStatus{
-			BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Status = v1alpha1.ImageClusterInstallStatus{
+			BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 				Name:      bmh.Name,
 				Namespace: bmh.Namespace,
 			},
@@ -612,12 +612,12 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(c.Create(ctx, newBMH)).To(Succeed())
 
-		clusterInstall.Spec.BareMetalHostRef = &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Spec.BareMetalHostRef = &v1alpha1.BareMetalHostReference{
 			Name:      newBMH.Name,
 			Namespace: newBMH.Namespace,
 		}
-		clusterInstall.Status = relocationv1alpha1.ImageClusterInstallStatus{
-			BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+		clusterInstall.Status = v1alpha1.ImageClusterInstallStatus{
+			BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 				Name:      oldBMH.Name,
 				Namespace: oldBMH.Namespace,
 			},
@@ -663,7 +663,7 @@ var _ = Describe("mapBMHToICI", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().
 			WithScheme(scheme.Scheme).
-			WithStatusSubresource(&relocationv1alpha1.ImageClusterInstall{}).
+			WithStatusSubresource(&v1alpha1.ImageClusterInstall{}).
 			Build()
 
 		r = &ImageClusterInstallReconciler{
@@ -682,13 +682,13 @@ var _ = Describe("mapBMHToICI", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterInstallName,
 				Namespace: clusterInstallNamespace,
 			},
-			Spec: relocationv1alpha1.ImageClusterInstallSpec{
-				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+			Spec: v1alpha1.ImageClusterInstallSpec{
+				BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 					Name:      bmh.Name,
 					Namespace: bmh.Namespace,
 				},
@@ -696,7 +696,7 @@ var _ = Describe("mapBMHToICI", func() {
 		}
 		Expect(c.Create(ctx, clusterInstall)).To(Succeed())
 
-		clusterInstall = &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall = &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "other-cluster-install",
 				Namespace: clusterInstallNamespace,
@@ -721,13 +721,13 @@ var _ = Describe("mapBMHToICI", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterInstallName,
 				Namespace: clusterInstallNamespace,
 			},
-			Spec: relocationv1alpha1.ImageClusterInstallSpec{
-				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+			Spec: v1alpha1.ImageClusterInstallSpec{
+				BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 					Name:      "other-bmh",
 					Namespace: bmh.Namespace,
 				},
@@ -735,7 +735,7 @@ var _ = Describe("mapBMHToICI", func() {
 		}
 		Expect(c.Create(ctx, clusterInstall)).To(Succeed())
 
-		clusterInstall = &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall = &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "other-cluster-install",
 				Namespace: clusterInstallNamespace,
@@ -759,7 +759,7 @@ var _ = Describe("mapCDToICI", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().
 			WithScheme(scheme.Scheme).
-			WithStatusSubresource(&relocationv1alpha1.ImageClusterInstall{}).
+			WithStatusSubresource(&v1alpha1.ImageClusterInstall{}).
 			Build()
 
 		r = &ImageClusterInstallReconciler{
@@ -777,8 +777,8 @@ var _ = Describe("mapCDToICI", func() {
 			},
 			Spec: hivev1.ClusterDeploymentSpec{
 				ClusterInstallRef: &hivev1.ClusterInstallLocalReference{
-					Group:   relocationv1alpha1.Group,
-					Version: relocationv1alpha1.Version,
+					Group:   v1alpha1.Group,
+					Version: v1alpha1.Version,
 					Kind:    "ImageClusterInstall",
 					Name:    clusterInstallName,
 				},
@@ -863,7 +863,7 @@ var _ = Describe("handleFinalizer", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().
 			WithScheme(scheme.Scheme).
-			WithStatusSubresource(&relocationv1alpha1.ImageClusterInstall{}).
+			WithStatusSubresource(&v1alpha1.ImageClusterInstall{}).
 			Build()
 		var err error
 		dataDir, err = os.MkdirTemp("", "imageclusterinstall_controller_test_data")
@@ -884,7 +884,7 @@ var _ = Describe("handleFinalizer", func() {
 	})
 
 	It("adds the finalizer if the cluster install is not being deleted", func() {
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterInstallName,
 				Namespace: clusterInstallNamespace,
@@ -905,7 +905,7 @@ var _ = Describe("handleFinalizer", func() {
 	})
 
 	It("noops if the finalizer is already present", func() {
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       clusterInstallName,
 				Namespace:  clusterInstallNamespace,
@@ -920,7 +920,7 @@ var _ = Describe("handleFinalizer", func() {
 	})
 
 	It("deletes the local files when the config is deleted", func() {
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       clusterInstallName,
 				Namespace:  clusterInstallNamespace,
@@ -968,14 +968,14 @@ var _ = Describe("handleFinalizer", func() {
 		}
 		Expect(c.Create(ctx, bmh)).To(Succeed())
 
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       clusterInstallName,
 				Namespace:  clusterInstallNamespace,
 				Finalizers: []string{clusterInstallFinalizerName},
 			},
-			Spec: relocationv1alpha1.ImageClusterInstallSpec{
-				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+			Spec: v1alpha1.ImageClusterInstallSpec{
+				BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 					Name:      bmh.Name,
 					Namespace: bmh.Namespace,
 				},
@@ -1008,14 +1008,14 @@ var _ = Describe("handleFinalizer", func() {
 	})
 
 	It("removes the finalizer if the referenced BMH doesn't exist", func() {
-		clusterInstall := &relocationv1alpha1.ImageClusterInstall{
+		clusterInstall := &v1alpha1.ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       clusterInstallName,
 				Namespace:  clusterInstallNamespace,
 				Finalizers: []string{clusterInstallFinalizerName},
 			},
-			Spec: relocationv1alpha1.ImageClusterInstallSpec{
-				BareMetalHostRef: &relocationv1alpha1.BareMetalHostReference{
+			Spec: v1alpha1.ImageClusterInstallSpec{
+				BareMetalHostRef: &v1alpha1.BareMetalHostReference{
 					Name:      "test-bmh",
 					Namespace: "test-bmh-namespace",
 				},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	relocationv1alpha1 "github.com/openshift/cluster-relocation-service/api/v1alpha1"
+	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	//+kubebuilder:scaffold:imports
 )
@@ -36,7 +36,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	Expect(relocationv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(bmh_v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(hivev1.AddToScheme(scheme.Scheme)).To(Succeed())
 })


### PR DESCRIPTION
This PR makes a few changes to ensure the new hive APIs are usable.

It adds the hive contract label to the CRD which is required for hive to recognize this type as a valid
ClusterInstall sub-type. Without this the hive admission webhook returns
an error like:

```
Error from server (Invalid): error when creating "cluster.yaml": admission webhook "clusterdeploymentvalidators.admission.hive.openshift.io" denied the request: ClusterDeployment.hive.openshift.io "test-sno" is invalid: spec.clusterInstallRef.kind: Unsupported value: "ImageClusterInstall": supported values: "extensions.hive.openshift.io/v1beta1, Kind=AgentClusterInstall", "hiveinternal.openshift.io/v1alpha1, Kind=FakeClusterInstall"
```

It also changes the API group to extensions.hive.openshift.io. This is required so that hive has permissions to access and edit the new
ClusterInstall type.

See
https://github.com/openshift/hive/blob/de169ddf445c3e064cfa8773de5af8ec00f649be/docs/enhancements/cluster-install-apis.md#external-clusterinstall-rbac
for details

Lastly it adds clusterimageset rbac which was missed in the previous PR.

Resolves https://issues.redhat.com/browse/MGMT-16618