### PR TITLE
MGMT-16554: Only fail the admission webhook if the spec was changed

### DIFF
--- a/api/v1alpha1/imageclusterinstall_webhook.go
+++ b/api/v1alpha1/imageclusterinstall_webhook.go
@@ -56,8 +56,8 @@ func (r *ImageClusterInstall) ValidateUpdate(old runtime.Object) (admission.Warn
 		return nil, nil
 	}
 
-	// Allow update if it's just the status
-	if isStatusUpdate(oldClusterInstall, r) {
+	// Allow update if it's not the spec
+	if !isSpecUpdate(oldClusterInstall, r) {
 		return nil, nil
 	}
 	if BMHRefsMatch(oldClusterInstall.Spec.BareMetalHostRef, r.Spec.BareMetalHostRef) {
@@ -66,12 +66,11 @@ func (r *ImageClusterInstall) ValidateUpdate(old runtime.Object) (admission.Warn
 	return nil, nil
 }
 
-func isStatusUpdate(oldClusterInstall *ImageClusterInstall, r *ImageClusterInstall) bool {
-	oldClusterInstallCopy := oldClusterInstall.DeepCopy()
-	oldClusterInstallCopy.Status = ImageClusterInstallStatus{}
-	newCopy := r.DeepCopy()
-	newCopy.Status = ImageClusterInstallStatus{}
-	return reflect.DeepEqual(oldClusterInstallCopy, newCopy)
+func isSpecUpdate(oldClusterInstall *ImageClusterInstall, newClusterInstall *ImageClusterInstall) bool {
+	oldSpec := oldClusterInstall.Spec.DeepCopy()
+	newSpec := newClusterInstall.Spec.DeepCopy()
+
+	return !reflect.DeepEqual(oldSpec, newSpec)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/imageclusterinstall_webhook_test.go
+++ b/api/v1alpha1/imageclusterinstall_webhook_test.go
@@ -115,6 +115,7 @@ var _ = Describe("ValidateUpdate", func() {
 		Expect(warns).To(BeNil())
 		Expect(err).ToNot(BeNil())
 	})
+
 	It("succeeds status update when BMH ref is set", func() {
 		oldClusterInstall := &ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{
@@ -142,6 +143,29 @@ var _ = Describe("ValidateUpdate", func() {
 		Expect(warns).To(BeNil())
 		Expect(err).To(BeNil())
 	})
+
+	It("metadata update succeeds when BMH ref is set", func() {
+		oldClusterInstall := &ImageClusterInstall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config",
+				Namespace: "test-namespace",
+			},
+			Spec: ImageClusterInstallSpec{
+				Hostname: "test",
+				BareMetalHostRef: &BareMetalHostReference{
+					Name:      "test-bmh",
+					Namespace: "test-bmh-namespace",
+				},
+			},
+		}
+		newClusterInstall := oldClusterInstall.DeepCopy()
+		newClusterInstall.ObjectMeta.Finalizers = []string{"somefinalizer"}
+
+		warns, err := newClusterInstall.ValidateUpdate(oldClusterInstall)
+		Expect(warns).To(BeNil())
+		Expect(err).To(BeNil())
+	})
+
 	It("fail status and spec update when BMH ref is set", func() {
 		oldClusterInstall := &ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Previously this was failing for status, and is now failing for metadata (specifically when removing the finalizer).

Resolves https://issues.redhat.com/browse/MGMT-16554