### PR TITLE
MGMT-16614: Update names referencing relocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openshift.io/cluster-relocation-service-bundle:$VERSION and openshift.io/cluster-relocation-service-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openshift.io/cluster-relocation-service
+# openshift.io/image-based-install-operator-bundle:$VERSION and openshift.io/image-based-install-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= openshift.io/image-based-install-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/PROJECT
+++ b/PROJECT
@@ -8,8 +8,8 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: cluster-relocation-service
-repo: github.com/openshift/cluster-relocation-service
+projectName: image-based-install-operator
+repo: github.com/openshift/image-based-install-operator
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: hive.openshift.io
   group: extensions
   kind: ImageClusterInstall
-  path: github.com/openshift/cluster-relocation-service/api/v1alpha1
+  path: github.com/openshift/image-based-install-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# cluster-relocation-service
-Configure relocated SNO clusters
+# image-based-install-operator
+Provide site configuration to Single Node OpenShift clusters to complete installation
 
 ## Description
-The cluster-relocation-service creates ISO images containing cluster configuration and optionally attaches them to relocated remote clusters using a BMH
+The image-based-install-operator creates ISO images containing cluster configuration and optionally attaches them to remote clusters using a BMH
 
 ## Getting Started
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
@@ -12,19 +12,19 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Build and push your image to the location specified by `IMG`:
 
 ```sh
-make build-image push IMG=<some-registry>/cluster-relocation-service:tag
+make build-image push IMG=<some-registry>/image-based-install-operator:tag
 ```
 
 2. Deploy the controller to the cluster with the image specified by `IMG`:
 
 ```sh
-make deploy IMG=<some-registry>/cluster-relocation-service:tag
+make deploy IMG=<some-registry>/image-based-install-operator:tag
 ```
 
-3. Create a cluster config resource
+3. Create an ImageClusterInstall resource
 
 ```sh
-kubectl apply -f config/samples/relocation_v1alpha1_imageclusterinstall.yaml
+kubectl apply -f config/samples/image-based-install_v1alpha1_imageclusterinstall.yaml
 ```
 
 ### Undeploy controller

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,10 +35,10 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
-	"github.com/openshift/cluster-relocation-service/controllers"
-	"github.com/openshift/cluster-relocation-service/internal/certs"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/image-based-install-operator/api/v1alpha1"
+	"github.com/openshift/image-based-install-operator/controllers"
+	"github.com/openshift/image-based-install-operator/internal/certs"
 	"github.com/sirupsen/logrus"
 	//+kubebuilder:scaffold:imports
 )
@@ -107,7 +107,7 @@ func main() {
 	logger.SetReportCaller(true)
 
 	controllerOptions := &controllers.ImageClusterInstallReconcilerOptions{}
-	if err := envconfig.Process("cluster-relocation-service", controllerOptions); err != nil {
+	if err := envconfig.Process("image-based-install-operator", controllerOptions); err != nil {
 		setupLog.Error(err, "unable to process envconfig")
 		os.Exit(1)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/openshift/cluster-relocation-service/internal/imageserver"
+	"github.com/openshift/image-based-install-operator/internal/imageserver"
 	"github.com/sirupsen/logrus"
 )
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cluster-relocation
+namespace: image-based-install-operator
 
 bases:
 - ../crd

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-relocation
+  name: image-based-install-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cluster-relocation-service
-  namespace: cluster-relocation
+  name: image-based-install-operator
+  namespace: image-based-install-operator
   labels:
-    app: cluster-relocation
+    app: image-based-install-operator
 spec:
   selector:
     matchLabels:
-      app: cluster-relocation
+      app: image-based-install-operator
   replicas: 1
   template:
     metadata:
       labels:
-        app: cluster-relocation
+        app: image-based-install-operator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -37,7 +37,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SERVICE_NAME
-          value: cluster-relocation-config
+          value: image-based-install-config
         - name: SERVICE_PORT
           value: "8000"
         - name: SERVICE_SCHEME
@@ -107,7 +107,7 @@ spec:
         emptyDir: {}
       - name: certs
         secret:
-          secretName: cluster-relocation-server
+          secretName: ibi-config-serving-certs
       - name: webhook-certs
         secret:
           secretName: webhook-certs
@@ -117,14 +117,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cluster-relocation-config
-  namespace: cluster-relocation
+  name: image-based-install-config
+  namespace: image-based-install-operator
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: cluster-relocation-server
+    service.beta.openshift.io/serving-cert-secret-name: ibi-config-serving-certs
 spec:
   ports:
   - port: 8000
     protocol: TCP
     name: config-server
   selector:
-    app: cluster-relocation
+    app: image-based-install-operator

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/cluster-relocation-service.clusterserviceversion.yaml
+- bases/image-based-install-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: controller-manager-metrics-monitor
-  namespace: cluster-relocation
+  namespace: image-based-install-operator
 spec:
   endpoints:
     - path: /metrics

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: leader-election
-  namespace: cluster-relocation
+  namespace: image-based-install-operator
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election
-  namespace: cluster-relocation
+  namespace: image-based-install-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: cluster-relocation
+  namespace: image-based-install-operator

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: cluster-relocation
+  namespace: image-based-install-operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
-  namespace: cluster-relocation
+  namespace: image-based-install-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -11,4 +11,4 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
-    app: cluster-relocation
+    app: image-based-install-operator

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -48,10 +48,10 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	lca_api "github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
-	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
-	"github.com/openshift/cluster-relocation-service/internal/certs"
-	"github.com/openshift/cluster-relocation-service/internal/filelock"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/image-based-install-operator/api/v1alpha1"
+	"github.com/openshift/image-based-install-operator/internal/certs"
+	"github.com/openshift/image-based-install-operator/internal/filelock"
 	"github.com/sirupsen/logrus"
 )
 

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -20,9 +20,9 @@ import (
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	lca_api "github.com/openshift-kni/lifecycle-agent/api/seedreconfig"
-	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
-	"github.com/openshift/cluster-relocation-service/internal/certs"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/image-based-install-operator/api/v1alpha1"
+	"github.com/openshift/image-based-install-operator/internal/certs"
 	"github.com/sirupsen/logrus"
 
 	. "github.com/onsi/ginkgo/v2"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/openshift/cluster-relocation-service/api/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/image-based-install-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/cluster-relocation-service
+module github.com/openshift/image-based-install-operator
 
 go 1.19
 

--- a/internal/imageserver/imageserver.go
+++ b/internal/imageserver/imageserver.go
@@ -14,7 +14,7 @@ import (
 	"github.com/diskfs/go-diskfs/disk"
 	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/diskfs/go-diskfs/filesystem/iso9660"
-	"github.com/openshift/cluster-relocation-service/internal/filelock"
+	"github.com/openshift/image-based-install-operator/internal/filelock"
 	"github.com/sirupsen/logrus"
 )
 

--- a/internal/imageserver/imageserver_test.go
+++ b/internal/imageserver/imageserver_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ServeHttp", func() {
 		workDir    string
 		configsDir string
 
-		namespace = "cluster-relocation"
+		namespace = "image-based-install-operator"
 		name      = "config"
 	)
 


### PR DESCRIPTION
This commit changes any names referencing relocation to something that agrees with the new repo name. This includes the module/import path as well as the operator namespace and all the object names in the operator deploy manifests.

This doesn't handle the group name as that is involved with the hive API work and is solved in https://github.com/openshift/image-based-install-operator/pull/27

Resolves https://issues.redhat.com/browse/MGMT-16614