### PR TITLE
Use the cluster deployment name for the kubeconfig secret name

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -555,7 +555,7 @@ func (r *ImageClusterInstallReconciler) CreateKubeconfigSecret(ctx context.Conte
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cd.Spec.ClusterName + "-admin-kubeconfig",
+			Name:      cd.Name + "-admin-kubeconfig",
 			Namespace: cd.Namespace,
 		},
 		Type: corev1.SecretTypeOpaque,


### PR DESCRIPTION
When using the cluster name from the spec we might override kubeconfig that belong to another cluster that happens to share the same cluster name