### PR TITLE
MGMT-16646: Clear the pull secret metadata

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -605,9 +605,11 @@ func (r *ImageClusterInstallReconciler) writePullSecretToFile(ctx context.Contex
 		return err
 	}
 
-	// override name and namespace
-	s.Name = "pull-secret"
-	s.Namespace = "openshift-config"
+	// override name and namespace and clear metadata
+	s.ObjectMeta = metav1.ObjectMeta{
+		Name:      "pull-secret",
+		Namespace: "openshift-config",
+	}
 
 	data, err := json.Marshal(s)
 	if err != nil {

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -154,12 +154,13 @@ var _ = Describe("Reconcile", func() {
 		Expect(*infoOut).To(Equal(info))
 	})
 
-	It("creates the pull secret", func() {
+	It("creates the pull secret without extra metadata", func() {
 		pullSecretData := map[string][]byte{"pullsecret": []byte("pullsecret")}
 		s := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pull-secret",
 				Namespace: clusterInstallNamespace,
+				UID:       types.UID("22ce1ffc-aa2d-477e-87b6-2a755f332e41"),
 			},
 			Data: pullSecretData,
 		}
@@ -184,6 +185,7 @@ var _ = Describe("Reconcile", func() {
 
 		Expect(secret.Namespace).To(Equal("openshift-config"))
 		Expect(secret.Name).To(Equal("pull-secret"))
+		Expect(secret.UID).To(Equal(types.UID("")))
 		Expect(secret.Data).To(Equal(pullSecretData))
 	})
 


### PR DESCRIPTION
Before this attempting to apply this secret directly to the spoke cluster was failing because of this additional metadata.

Resolves https://issues.redhat.com/browse/MGMT-16646