### PR TITLE
MGMT-16650 Regenerate cluster crypto only when needed

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -93,8 +93,8 @@ func (r *KubeConfigCertManager) GenerateKubeApiserverServingSigningCerts() error
 	return nil
 }
 
-func (r *KubeConfigCertManager) GetCrypto() lca_api.KubeConfigCryptoRetention {
-	return r.crypto
+func (r *KubeConfigCertManager) GetCrypto() *lca_api.KubeConfigCryptoRetention {
+	return &r.crypto
 }
 
 // GenerateIngressServingSigningCerts Create the ingress serving signer CAs and adds them to the cluster CA bundle


### PR DESCRIPTION
Prior to this change, IBIO renders the cluster crypto 4 times in case of happy flow. It's useless time consuming and error prone (we might accidintly override the cluster kubeconfig) This change will generate new crypto in case the current cluster crypto doesn't match the current cluster name and basedomain.