### PR TITLE
MGMT-16930: Fix credentials secret owner RBAC

### DIFF
--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-02-13T13:57:45Z"
+    createdAt: "2024-02-15T13:53:12Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -108,6 +108,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments/finalizers
+          verbs:
+          - update
         - apiGroups:
           - hive.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,12 @@ rules:
 - apiGroups:
   - hive.openshift.io
   resources:
+  - clusterdeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - hive.openshift.io
+  resources:
   - clusterimagesets
   verbs:
   - get

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -104,6 +104,7 @@ const (
 //+kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls/finalizers,verbs=update
 //+kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch
 
 func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -136,7 +136,7 @@ func (r *Credentials) createOrUpdateClusterCredentialSecret(ctx context.Context,
 		Kind:               deploymentGVK.Kind,
 		Name:               cd.Name,
 		UID:                cd.UID,
-		BlockOwnerDeletion: pointer.Bool(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}}
 	mutateFn := func() error {
 		// Update the Secret object with the desired data


### PR DESCRIPTION
This is required to set the owner reference for the credential secrets to the cluster deployment.

Without this reconcile errors with:

```
2024-02-15T13:27:42Z	ERROR	Reconciler error	{"controller": "imageclusterinstall", "controllerGroup": "extensions.hive.openshift.io", "controllerKind": "ImageClusterInstall", "ImageClusterInstall": {"name":"ibi-test","namespace":"ibi-test"}, "namespace": "ibi-test", "name": "ibi-test", "reconcileID": "4130c019-a6b0-4131-9d6e-e51fff203cfc", "error": "failed to write input data: failed to ensure admin password secret: failed to create kubeadmin password secret: failed to create secret: secrets \"ibi-test-admin-password\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

Resolves https://issues.redhat.com/browse/MGMT-16930