### PR TITLE
Set kubeadminPasswordSecret name correctly

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -666,7 +666,7 @@ func (r *ImageClusterInstallReconciler) setClusterInstallMetadata(ctx context.Co
 			Name: kubeconfigSecret,
 		},
 		AdminPasswordSecretRef: &corev1.LocalObjectReference{
-			Name: kubeconfigSecret,
+			Name: kubeadminPasswordSecret,
 		},
 	}
 

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -1021,6 +1021,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(meta.InfraID).To(HavePrefix("thingcluster"))
 			Expect(meta.InfraID).To(Equal(infoOut.InfraID))
 			Expect(meta.AdminKubeconfigSecretRef.Name).To(Equal("test-cluster-admin-kubeconfig"))
+			Expect(meta.AdminPasswordSecretRef.Name).To(Equal("test-cluster-admin-password"))
 		}
 
 		updatedICI := v1alpha1.ImageClusterInstall{}


### PR DESCRIPTION
Previously this was incorrectly set to the kubeconfig secret name. This was causing constant reconciles as the values seem to be copied from the cluster install to the cluster deployment which we then reset (as we are setting both).