### PR TITLE
MGMT-17619: Align cluster install usage with hive expectations

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -33,8 +33,14 @@ const (
 	HostConfiguraionSucceededReason   = "HostConfigurationSucceeded"
 	HostConfigurationSucceededMessage = "Configuration image is attached to the referenced host"
 
-	InstallTimedoutReason   = "ClusterInstallationTimedOut"
-	InstallInProgressReason = "ClusterInstallationInProgress"
+	InstallTimedoutReason  = "ClusterInstallationTimedOut"
+	InstallTimedoutMessage = "Cluster installation has timed out"
+
+	InstallInProgressReason  = "ClusterInstallationInProgress"
+	InstallInProgressMessage = "Cluster installation is in progress"
+
+	InstallSucceededReason  = "ClusterInstallationSucceeded"
+	InstallSucceededMessage = "Cluster installation has succeeded"
 )
 
 // ImageClusterInstallSpec defines the desired state of ImageClusterInstall

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -46,20 +46,38 @@ func setClusterInstallCondition(conditions *[]hivev1.ClusterInstallCondition, ne
 }
 
 func (r *ImageClusterInstallReconciler) initializeConditions(ctx context.Context, ici *v1alpha1.ImageClusterInstall) error {
-	initialTypeStatus := map[hivev1.ClusterInstallConditionType]corev1.ConditionStatus{
-		hivev1.ClusterInstallRequirementsMet: corev1.ConditionUnknown,
-		hivev1.ClusterInstallCompleted:       corev1.ConditionUnknown,
-		hivev1.ClusterInstallFailed:          corev1.ConditionUnknown,
-		hivev1.ClusterInstallStopped:         corev1.ConditionFalse,
+	initialConditions := []hivev1.ClusterInstallCondition{
+		{
+			Type:    hivev1.ClusterInstallRequirementsMet,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "Unknown",
+			Message: "Unknown",
+		},
+		{
+			Type:    hivev1.ClusterInstallCompleted,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "Unknown",
+			Message: "Unknown",
+		},
+		{
+			Type:    hivev1.ClusterInstallFailed,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "Unknown",
+			Message: "Unknown",
+		},
+		{
+			Type:    hivev1.ClusterInstallStopped,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "Unknown",
+			Message: "Unknown",
+		},
 	}
 
 	patch := client.MergeFrom(ici.DeepCopy())
-	for condType, status := range initialTypeStatus {
-		if findCondition(ici.Status.Conditions, condType) == nil {
-			setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-				Type:   condType,
-				Status: status,
-			})
+	for _, cond := range initialConditions {
+		// only set the initial status if the condition doesn't exist already
+		if findCondition(ici.Status.Conditions, cond.Type) == nil {
+			setClusterInstallCondition(&ici.Status.Conditions, cond)
 		}
 	}
 
@@ -108,16 +126,22 @@ func (r *ImageClusterInstallReconciler) setHostConfiguredCondition(ctx context.C
 func (r *ImageClusterInstallReconciler) setClusterInstalledConditions(ctx context.Context, ici *v1alpha1.ImageClusterInstall) error {
 	patch := client.MergeFrom(ici.DeepCopy())
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallCompleted,
-		Status: corev1.ConditionTrue,
+		Type:    hivev1.ClusterInstallCompleted,
+		Status:  corev1.ConditionTrue,
+		Reason:  v1alpha1.InstallSucceededReason,
+		Message: v1alpha1.InstallSucceededMessage,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallStopped,
-		Status: corev1.ConditionTrue,
+		Type:    hivev1.ClusterInstallStopped,
+		Status:  corev1.ConditionTrue,
+		Reason:  v1alpha1.InstallSucceededReason,
+		Message: v1alpha1.InstallSucceededMessage,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallFailed,
-		Status: corev1.ConditionFalse,
+		Type:    hivev1.ClusterInstallFailed,
+		Status:  corev1.ConditionFalse,
+		Reason:  v1alpha1.InstallSucceededReason,
+		Message: v1alpha1.InstallSucceededMessage,
 	})
 
 	return r.Status().Patch(ctx, ici, patch)
@@ -133,8 +157,10 @@ func (r *ImageClusterInstallReconciler) setClusterTimeoutConditions(ctx context.
 		Message: message,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallStopped,
-		Status: corev1.ConditionTrue,
+		Type:    hivev1.ClusterInstallStopped,
+		Status:  corev1.ConditionTrue,
+		Reason:  v1alpha1.InstallTimedoutReason,
+		Message: v1alpha1.InstallTimedoutMessage,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
 		Type:    hivev1.ClusterInstallFailed,
@@ -149,9 +175,10 @@ func (r *ImageClusterInstallReconciler) setClusterTimeoutConditions(ctx context.
 func (r *ImageClusterInstallReconciler) setClusterInstallingConditions(ctx context.Context, ici *v1alpha1.ImageClusterInstall, message string) error {
 	patch := client.MergeFrom(ici.DeepCopy())
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallCompleted,
-		Status: corev1.ConditionFalse,
-		Reason: v1alpha1.InstallInProgressReason,
+		Type:    hivev1.ClusterInstallCompleted,
+		Status:  corev1.ConditionFalse,
+		Reason:  v1alpha1.InstallInProgressReason,
+		Message: v1alpha1.InstallInProgressMessage,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
 		Type:    hivev1.ClusterInstallStopped,
@@ -160,9 +187,10 @@ func (r *ImageClusterInstallReconciler) setClusterInstallingConditions(ctx conte
 		Message: message,
 	})
 	setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
-		Type:   hivev1.ClusterInstallFailed,
-		Status: corev1.ConditionFalse,
-		Reason: v1alpha1.InstallInProgressReason,
+		Type:    hivev1.ClusterInstallFailed,
+		Status:  corev1.ConditionFalse,
+		Reason:  v1alpha1.InstallInProgressReason,
+		Message: v1alpha1.InstallInProgressMessage,
 	})
 
 	return r.Status().Patch(ctx, ici, patch)

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -290,13 +290,6 @@ func (r *ImageClusterInstallReconciler) checkClusterStatus(ctx context.Context, 
 	}
 	log.Info("cluster is installed")
 
-	// set installed in spec and conditions after monitoring has finished
-	patch := client.MergeFrom(clusterDeployment.DeepCopy())
-	clusterDeployment.Spec.Installed = true
-	if err := r.Patch(ctx, clusterDeployment, patch); err != nil {
-		log.WithError(err).Error("failed to mark cluster deployment as installed")
-		return ctrl.Result{}, err
-	}
 	if err := r.setClusterInstalledConditions(ctx, ici); err != nil {
 		log.WithError(err).Error("failed to set installed conditions")
 		return ctrl.Result{}, err

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -1197,23 +1197,15 @@ var _ = Describe("Reconcile", func() {
 		infoOut := &lca_api.SeedReconfiguration{}
 		Expect(json.Unmarshal(content, infoOut)).To(Succeed())
 
-		validateMeta := func(meta *hivev1.ClusterMetadata) {
-			Expect(meta).ToNot(BeNil())
-			Expect(meta.ClusterID).To(Equal(infoOut.ClusterID))
-			Expect(meta.InfraID).To(HavePrefix("thingcluster"))
-			Expect(meta.InfraID).To(Equal(infoOut.InfraID))
-			Expect(meta.AdminKubeconfigSecretRef.Name).To(Equal("test-cluster-admin-kubeconfig"))
-			Expect(meta.AdminPasswordSecretRef.Name).To(Equal("test-cluster-admin-password"))
-		}
-
 		updatedICI := v1alpha1.ImageClusterInstall{}
 		Expect(c.Get(ctx, key, &updatedICI)).To(Succeed())
-		validateMeta(updatedICI.Spec.ClusterMetadata)
-
-		updatedCD := hivev1.ClusterDeployment{}
-		Expect(c.Get(ctx, key, &updatedCD)).To(Succeed())
-
-		validateMeta(updatedCD.Spec.ClusterMetadata)
+		meta := updatedICI.Spec.ClusterMetadata
+		Expect(meta).ToNot(BeNil())
+		Expect(meta.ClusterID).To(Equal(infoOut.ClusterID))
+		Expect(meta.InfraID).To(HavePrefix("thingcluster"))
+		Expect(meta.InfraID).To(Equal(infoOut.InfraID))
+		Expect(meta.AdminKubeconfigSecretRef.Name).To(Equal("test-cluster-admin-kubeconfig"))
+		Expect(meta.AdminPasswordSecretRef.Name).To(Equal("test-cluster-admin-password"))
 	})
 
 	It("sets the clusterID to the manifest.json value if it exists", func() {


### PR DESCRIPTION
~~Built on https://github.com/openshift/image-based-install-operator/pull/52~~ Merged
~~Requires https://github.com/openshift/hive/pull/2267~~ Merged

Hive will copy the cluster metadata, set the installed field, and will also only set conditions if the message or reason was updated.

Resolves https://issues.redhat.com/browse/MGMT-17619