### PR TITLE
MGMT-17597: Rescheduling IBIO after install begins invalidates kubeconfig and certs

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -562,6 +562,7 @@ func (r *ImageClusterInstallReconciler) writeInputData(ctx context.Context, log 
 			return err
 		}
 		clusterInfo := r.getClusterInfoFromFile(clusterInfoFilePath)
+
 		crypto, err := r.Credentials.EnsureKubeconfigSecret(ctx, cd, clusterInfo)
 		if err != nil {
 			return fmt.Errorf("failed to ensure kubeconifg secret: %w", err)
@@ -646,7 +647,12 @@ func (r *ImageClusterInstallReconciler) nmstateConfig(ctx context.Context, ici *
 	return nmstate, nil
 }
 
-func (r *ImageClusterInstallReconciler) writeClusterInfo(ctx context.Context, log logrus.FieldLogger, ici *v1alpha1.ImageClusterInstall, cd *hivev1.ClusterDeployment, KubeconfigCryptoRetention lca_api.KubeConfigCryptoRetention, psData, kubeadminPasswordHash string, file string, existingInfo *lca_api.SeedReconfiguration) error {
+func (r *ImageClusterInstallReconciler) writeClusterInfo(ctx context.Context, log logrus.FieldLogger,
+	ici *v1alpha1.ImageClusterInstall, cd *hivev1.ClusterDeployment,
+	KubeconfigCryptoRetention lca_api.KubeConfigCryptoRetention,
+	psData, kubeadminPasswordHash, file string,
+	existingInfo *lca_api.SeedReconfiguration) error {
+
 	nmstate, err := r.nmstateConfig(ctx, ici)
 	if err != nil {
 		return err

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -113,6 +113,19 @@ var _ = Describe("Credentials", func() {
 		kubeconfigSecretData2 := getKubeconfigFromSecret(ctx, cm.Client, clusterDeployment)
 		Expect(string(kubeconfigSecretData2)).To(Equal(string(kubeconfigSecretData)))
 	})
+	It("EnsureKubeconfigSecret already exists and valid - but seed reconfiguration is nil, content should be the same", func() {
+		kubeConfigCryptoRetention, err := cm.EnsureKubeconfigSecret(ctx, clusterDeployment, nil)
+		Expect(err).NotTo(HaveOccurred())
+		kubeconfigSecretData := getKubeconfigFromSecret(ctx, cm.Client, clusterDeployment)
+		// Call again and check the content is the same
+		kubeConfigCryptoRetention_2, err := cm.EnsureKubeconfigSecret(ctx, clusterDeployment, nil)
+		Expect(err).NotTo(HaveOccurred())
+		// Verify same cluster crypto
+		Expect(kubeConfigCryptoRetention_2).To(Equal(kubeConfigCryptoRetention))
+		// Verify the kubeconfig secret data hasn't changed
+		kubeconfigSecretData2 := getKubeconfigFromSecret(ctx, cm.Client, clusterDeployment)
+		Expect(string(kubeconfigSecretData2)).To(Equal(string(kubeconfigSecretData)))
+	})
 	It("EnsureAdminPasswordSecret success", func() {
 		passwordHash, err := cm.EnsureAdminPasswordSecret(ctx, clusterDeployment)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
[MGMT-17597](https://issues.redhat.com//browse/MGMT-17597): Rescheduling IBIO after install begins invalidates kubeconfig and certs

Saving crypto keys in secret and reading them from it in case kubeconfig url is valid