### PR TITLE
ACM-13444: Update images to use registry.access.redhat.com bases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
@@ -14,19 +13,17 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 COPY vendor/ vendor/
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/manager/main.go
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o server cmd/server/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/manager cmd/manager/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
-
-#RUN microdnf install glibc-devel
 
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR
 
 WORKDIR /
-COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/server .
+COPY --from=builder /opt/app-root/src/build/manager /usr/local/bin/
+COPY --from=builder /opt/app-root/src/build/server /usr/local/bin/
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-08-14T18:06:35Z"
+    createdAt: "2024-08-14T18:10:16Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -160,7 +160,7 @@ spec:
               - args:
                 - --leader-elect
                 command:
-                - /manager
+                - /usr/local/bin/manager
                 env:
                 - name: ROUTE_NAMESPACE
                   valueFrom:
@@ -204,7 +204,7 @@ spec:
                 - mountPath: /webhook-certs
                   name: webhook-certs
               - command:
-                - /server
+                - /usr/local/bin/server
                 env:
                 - name: HTTPS_KEY_FILE
                   value: /certs/tls.key

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /usr/local/bin/manager
         args:
         - --leader-elect
         image: controller:latest
@@ -72,7 +72,7 @@ spec:
         - name: webhook-certs
           mountPath: /webhook-certs
       - command:
-        - /server
+        - /usr/local/bin/server
         image: controller:latest
         name: server
         env:


### PR DESCRIPTION
This also involved changing some of where the resulting executables were placed which then required a bundle update.

WIP until https://github.com/openshift/image-based-install-operator/pull/69 is merged.