### PR TITLE
NO-ISSUE: Remove ICI version field

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -62,10 +62,6 @@ type ImageClusterInstallSpec struct {
 	// +optional
 	ClusterMetadata *hivev1.ClusterMetadata `json:"clusterMetadata"`
 
-	// Version is the target OCP version for the cluster
-	// TODO: should this use ImageSetRef?
-	Version string `json:"version,omitempty"`
-
 	// NodeIP is the desired IP for the host
 	// +optional
 	// Deprecated: this field is ignored (will be removed in a future release).

--- a/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -283,10 +283,6 @@ spec:
                   access to instances. Equivalent to install-config.yaml's sshKey.
                   This key will be added to the host to allow ssh access
                 type: string
-              version:
-                description: 'Version is the target OCP version for the cluster TODO:
-                  should this use ImageSetRef?'
-                type: string
             required:
             - imageSetRef
             type: object


### PR DESCRIPTION
The only use of this field was removed in
b44908563ec35f5cc02647181e1f382cce107c6c and if we need something from the version in the future we should be getting it from the ClusterImageSet