### PR TITLE
MGMT-18704: Slow performance while attempting to Install many SNOs via Image Cluster Installs with IBI Operator

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -272,6 +272,14 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 				log.WithError(err).Error("failed to set Status.BareMetalHostRef")
 				return ctrl.Result{}, err
 			}
+			// as we are updating ici here we should return without RequeueAfter
+			// as reconcilation will run on update
+			return ctrl.Result{}, nil
+		}
+
+		if bmh.Status.Provisioning.State != bmh_v1alpha1.StateProvisioned {
+			log.Infof("BareMetalHost %s/%s is not provisioned yet, requeueing", bmh.Name, bmh.Namespace)
+			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 
 		timedout, err := r.checkClusterTimeout(ctx, log, ici, r.DefaultInstallTimeout)


### PR DESCRIPTION
[MGMT-18704](https://issues.redhat.com//browse/MGMT-18704): Slow performance while attempting to Install many SNOs via Image Cluster Installs with IBI Operator
We should not try to connect to CVO if bmh is not provisioned, this causes us to stuck in spoke client for timeout as cluster can't be started yet