### PR TITLE
MGMT-18860: create ibio start cm

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -760,6 +760,9 @@ func (r *ImageClusterInstallReconciler) writeInputData(
 		if err := r.writeInvokerCM(filepath.Join(manifestsPath, invokerCMFileName)); err != nil {
 			return fmt.Errorf("failed to write invoker config map: %w", err)
 		}
+		if err := r.writeIBIOStartTimeCM(filepath.Join(manifestsPath, monitor.IBIOStartTimeCM+".yaml")); err != nil {
+			return fmt.Errorf("failed to write %s config map: %w", monitor.IBIOStartTimeCM, err)
+		}
 
 		if ici.Spec.ExtraManifestsRefs != nil {
 			extraManifestsPath := filepath.Join(filesDir, extraManifestsDir)
@@ -1256,6 +1259,27 @@ func (r *ImageClusterInstallReconciler) writeInvokerCM(filePath string) error {
 	data, err := json.Marshal(cm)
 	if err != nil {
 		return fmt.Errorf("failed to marshal openshift-install-manifests: %w", err)
+	}
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+func (r *ImageClusterInstallReconciler) writeIBIOStartTimeCM(filePath string) error {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: monitor.OcpConfigNamespace,
+			Name:      monitor.IBIOStartTimeCM,
+		},
+	}
+	data, err := json.Marshal(cm)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", monitor.IBIOStartTimeCM, err)
 	}
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"testing"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
@@ -41,10 +42,11 @@ var _ = Describe("GetClusterInstallStatus", func() {
 			},
 			Status: configv1.ClusterVersionStatus{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
-					Type:    configv1.OperatorAvailable,
-					Status:  availableStatus,
-					Message: "message",
-					Reason:  "reason",
+					Type:               configv1.OperatorAvailable,
+					Status:             availableStatus,
+					Message:            "message",
+					Reason:             "reason",
+					LastTransitionTime: metav1.Time{Time: time.Now()},
 				}},
 			},
 		}
@@ -66,10 +68,27 @@ var _ = Describe("GetClusterInstallStatus", func() {
 		Expect(c.Create(ctx, &node)).To(Succeed())
 	}
 
+	createIBIOStartTimeCM := func(createdAt time.Time) {
+		cm := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         OcpConfigNamespace,
+				Name:              IBIOStartTimeCM,
+				CreationTimestamp: metav1.Time{Time: createdAt},
+			},
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+	}
+
 	It("returns true when the cluster version is available and nodes are ready", func() {
 		createNode("node1", corev1.ConditionTrue)
 		createNode("node2", corev1.ConditionTrue)
 		createNode("node3", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now())
+
 		createClusterVersion(configv1.ConditionTrue)
 
 		status := GetClusterInstallStatus(ctx, log, c)
@@ -82,6 +101,7 @@ var _ = Describe("GetClusterInstallStatus", func() {
 		createNode("node1", corev1.ConditionFalse)
 		createNode("node2", corev1.ConditionTrue)
 		createNode("node3", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now())
 		createClusterVersion(configv1.ConditionTrue)
 
 		status := GetClusterInstallStatus(ctx, log, c)
@@ -92,6 +112,7 @@ var _ = Describe("GetClusterInstallStatus", func() {
 
 	It("returns false when the cluster version is not available", func() {
 		createNode("node1", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now())
 		createClusterVersion(configv1.ConditionFalse)
 
 		status := GetClusterInstallStatus(ctx, log, c)
@@ -101,12 +122,78 @@ var _ = Describe("GetClusterInstallStatus", func() {
 	})
 
 	It("returns false when no nodes exist", func() {
+		createIBIOStartTimeCM(time.Now())
 		createClusterVersion(configv1.ConditionTrue)
 
 		status := GetClusterInstallStatus(ctx, log, c)
 		Expect(status.Installed).To(BeFalse())
 		Expect(status.ClusterVersionStatus).To(Equal(clusterVersionAvailableMessage))
 		Expect(status.NodesStatus).ToNot(Equal(nodesReadyMessage))
+	})
+
+	It("returns false when cm does not exists", func() {
+		createNode("node1", corev1.ConditionTrue)
+		createClusterVersion(configv1.ConditionTrue)
+
+		status := GetClusterInstallStatus(ctx, log, c)
+		Expect(status.Installed).To(BeFalse())
+		Expect(status.ClusterVersionStatus).To(ContainSubstring("Failed to get"))
+	})
+
+	It("returns false when cm is more than an hour ahead of cvo last transition", func() {
+		createNode("node1", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now().Add(61 * time.Minute))
+		createClusterVersion(configv1.ConditionTrue)
+
+		status := GetClusterInstallStatus(ctx, log, c)
+		Expect(status.Installed).To(BeFalse())
+		Expect(status.ClusterVersionStatus).To(Equal(clusterVersionNotAvailableMessage))
+		Expect(status.NodesStatus).To(Equal(nodesReadyMessage))
+	})
+
+	It("returns true when cm creation data is 2 hours before  cvo last transition", func() {
+		createNode("node1", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now().Add(-120 * time.Minute))
+		createClusterVersion(configv1.ConditionTrue)
+
+		status := GetClusterInstallStatus(ctx, log, c)
+		Expect(status.Installed).To(BeTrue())
+		Expect(status.ClusterVersionStatus).To(Equal(clusterVersionAvailableMessage))
+		Expect(status.NodesStatus).To(Equal(nodesReadyMessage))
+	})
+
+	It("returns true in case available condition was not updated but progressing was ", func() {
+		createNode("node1", corev1.ConditionTrue)
+		createIBIOStartTimeCM(time.Now())
+		cv := configv1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "version",
+			},
+			Spec: configv1.ClusterVersionSpec{
+				ClusterID: "2df3ed12-a142-437d-a398-c551dfd8e9ba",
+			},
+			Status: configv1.ClusterVersionStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionTrue,
+					Message:            "message",
+					Reason:             "reason",
+					LastTransitionTime: metav1.Time{Time: time.Now().Add(-120 * time.Minute)},
+				}, {
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionFalse,
+					Message:            "message",
+					Reason:             "reason",
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+				},
+			},
+		}
+		Expect(c.Create(ctx, &cv)).To(Succeed())
+		status := GetClusterInstallStatus(ctx, log, c)
+		Expect(status.Installed).To(BeTrue())
+		Expect(status.ClusterVersionStatus).To(Equal(clusterVersionAvailableMessage))
+		Expect(status.NodesStatus).To(Equal(nodesReadyMessage))
 	})
 })
 


### PR DESCRIPTION
    MGMT-18860: IBIO report installtion complete although the cluster is still reconfiguring
    Create new cm in order to get creation timestamp that will point us to
    the time when cluster started to run
    Check conditions in CVO and verify that at least one was changed after
    cm creation timestamp