### PR TITLE
MGMT-18865: always read crypto values from secret and not from seedreconfiguration object

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -798,7 +798,7 @@ func (r *ImageClusterInstallReconciler) writeInputData(
 			clusterInfo = &lca_api.SeedReconfiguration{}
 		}
 
-		crypto, err := r.Credentials.EnsureKubeconfigSecret(ctx, cd, clusterInfo)
+		crypto, err := r.Credentials.EnsureKubeconfigSecret(ctx, cd)
 		if err != nil {
 			return fmt.Errorf("failed to ensure kubeconifg secret: %w", err)
 		}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -48,17 +48,12 @@ type Credentials struct {
 	Scheme *runtime.Scheme
 }
 
-func (r *Credentials) EnsureKubeconfigSecret(ctx context.Context, cd *hivev1.ClusterDeployment, clusterInfo *lca_api.SeedReconfiguration) (lca_api.KubeConfigCryptoRetention, error) {
+func (r *Credentials) EnsureKubeconfigSecret(ctx context.Context, cd *hivev1.ClusterDeployment) (lca_api.KubeConfigCryptoRetention, error) {
 	url := fmt.Sprintf("https://api.%s.%s:6443", cd.Spec.ClusterName, cd.Spec.BaseDomain)
 
 	existsAndValid, err := r.kubeconfigExistsAndValid(ctx, cd, url)
 	if err != nil {
 		return lca_api.KubeConfigCryptoRetention{}, err
-	}
-	// nothing was changed, return the existing crypto
-	if existsAndValid && clusterInfo != nil {
-		r.Log.Infof("Kubeconfig already exists and is valid, taking crypto from seed reconfiguration")
-		return clusterInfo.KubeconfigCryptoRetention, nil
 	}
 
 	cryptoData, err := r.ensureCryptoKeys(ctx, cd, !existsAndValid)


### PR DESCRIPTION
[MGMT-18865](https://issues.redhat.com//browse/MGMT-18865): always read crypto values from secret and not from seedreconfiguration object