### PR TITLE
MGMT-18662 Remove static netowrk ref from the ICI

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -83,11 +83,6 @@ type ImageClusterInstallSpec struct {
 	// The tls-ca-bundle.pem entry in the config map will be written to /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 	CABundleRef *corev1.LocalObjectReference `json:"caBundleRef,omitempty"`
 
-	// NetworkConfigRef is the reference to a config map containing network configuration files if necessary.
-	// Keys should be of the form *.nmconnection and each represent an nmconnection file to be applied to the host.
-	// +optional
-	NetworkConfigRef *corev1.LocalObjectReference `json:"networkConfigRef,omitempty"`
-
 	// ExtraManifestsRefs is list of config map references containing additional manifests to be applied to the relocated cluster.
 	// +optional
 	ExtraManifestsRefs []corev1.LocalObjectReference `json:"extraManifestsRef,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -127,11 +127,6 @@ func (in *ImageClusterInstallSpec) DeepCopyInto(out *ImageClusterInstallSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
-	if in.NetworkConfigRef != nil {
-		in, out := &in.NetworkConfigRef, &out.NetworkConfigRef
-		*out = new(v1.LocalObjectReference)
-		**out = **in
-	}
 	if in.ExtraManifestsRefs != nil {
 		in, out := &in.ExtraManifestsRefs, &out.ExtraManifestsRefs
 		*out = make([]v1.LocalObjectReference, len(*in))

--- a/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -259,18 +259,6 @@ spec:
                   This will be used to create the node network and choose ip address for the node.
                   Equivalent to install-config.yaml's machineNetwork.
                 type: string
-              networkConfigRef:
-                description: |-
-                  NetworkConfigRef is the reference to a config map containing network configuration files if necessary.
-                  Keys should be of the form *.nmconnection and each represent an nmconnection file to be applied to the host.
-                properties:
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               nodeIP:
                 description: |-
                   NodeIP is the desired IP for the host

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-04T17:04:35Z"
+    createdAt: "2024-09-11T10:52:15Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1

--- a/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -257,18 +257,6 @@ spec:
                   This will be used to create the node network and choose ip address for the node.
                   Equivalent to install-config.yaml's machineNetwork.
                 type: string
-              networkConfigRef:
-                description: |-
-                  NetworkConfigRef is the reference to a config map containing network configuration files if necessary.
-                  Keys should be of the form *.nmconnection and each represent an nmconnection file to be applied to the host.
-                properties:
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               nodeIP:
                 description: |-
                   NodeIP is the desired IP for the host


### PR DESCRIPTION
Following this change static network config is supported only via PreprovisioningNetworkDataName on the BMH spec

This should reduce the code complexity and confusion e.g. https://issues.redhat.com/browse/CNF-14123