### PR TITLE
MGMT-18898: Allow transition from ClusterInstallationTimedOut to installComplete

### DIFF
--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -219,8 +219,13 @@ func (r *ImageClusterInstallReconciler) setClusterTimeoutConditions(ctx context.
 	return r.Status().Patch(ctx, ici, patch)
 }
 
-func installationStopped(ici *v1alpha1.ImageClusterInstall) bool {
-	cond := findCondition(ici.Status.Conditions, hivev1.ClusterInstallStopped)
+func installationTimedout(ici *v1alpha1.ImageClusterInstall) bool {
+	cond := findCondition(ici.Status.Conditions, hivev1.ClusterInstallCompleted)
+	return cond != nil && cond.Status == corev1.ConditionFalse && cond.Reason == v1alpha1.InstallTimedoutReason
+}
+
+func installationCompleted(ici *v1alpha1.ImageClusterInstall) bool {
+	cond := findCondition(ici.Status.Conditions, hivev1.ClusterInstallCompleted)
 	return cond != nil && cond.Status == corev1.ConditionTrue
 }
 


### PR DESCRIPTION
[MGMT-18898](https://issues.redhat.com//browse/MGMT-18898): Allow transition from ClusterInstallationTimedOut to installComplete
In case installation timed out but reconcilation ran we still want to validate if cluster managed to be installed or not, in case it finished successfully after timeout we will set installed