### PR TITLE
Revert "MGMT-18219: Update Dockerfile to use go1.22 ci image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
This reverts commit b89bac9ecc36b5fdd923536d10176f648cd6f18f.

/cc @eliorerz 