### PR TITLE
MGMT-18950: Set condition stopped to false in case of timeout

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -34,7 +34,7 @@ const (
 	HostConfigurationSucceededMessage = "Configuration image is attached to the referenced host"
 
 	InstallTimedoutReason  = "ClusterInstallationTimedOut"
-	InstallTimedoutMessage = "Cluster installation has timed out"
+	InstallTimedoutMessage = "Cluster installation is taking longer than expected"
 
 	InstallInProgressReason  = "ClusterInstallationInProgress"
 	InstallInProgressMessage = "Cluster installation is in progress"

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -202,7 +202,7 @@ func (r *ImageClusterInstallReconciler) setClusterTimeoutConditions(ctx context.
 	})
 	stoppedUpdated := setClusterInstallCondition(&ici.Status.Conditions, hivev1.ClusterInstallCondition{
 		Type:    hivev1.ClusterInstallStopped,
-		Status:  corev1.ConditionTrue,
+		Status:  corev1.ConditionFalse,
 		Reason:  v1alpha1.InstallTimedoutReason,
 		Message: v1alpha1.InstallTimedoutMessage,
 	})

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -1292,7 +1292,7 @@ var _ = Describe("Reconcile", func() {
 
 		cond := findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallStopped)
 		Expect(cond).NotTo(BeNil())
-		Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
 		cond = findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallFailed)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(corev1.ConditionTrue))
@@ -1333,7 +1333,7 @@ var _ = Describe("Reconcile", func() {
 
 		cond := findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallStopped)
 		Expect(cond).NotTo(BeNil())
-		Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
 		cond = findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallFailed)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(corev1.ConditionTrue))
@@ -1394,7 +1394,7 @@ var _ = Describe("Reconcile", func() {
 
 		cond := findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallStopped)
 		Expect(cond).NotTo(BeNil())
-		Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
 		cond = findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallFailed)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(corev1.ConditionTrue))


### PR DESCRIPTION
[MGMT-18950](https://issues.redhat.com//browse/MGMT-18950): Set condition stopped to false in case of timeout
As we allow to update status from timeout to installed we should not set stopped installation flag to false on timeout