### PR TITLE
Add patch and update permissions for configmap and rename service account

### DIFF
--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-19T18:20:10Z"
+    createdAt: "2024-09-19T18:30:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -152,7 +152,7 @@ spec:
           - patch
           - update
           - watch
-        serviceAccountName: controller-manager
+        serviceAccountName: image-based-install-operator
       deployments:
       - label:
           app: image-based-install-operator
@@ -250,7 +250,7 @@ spec:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
-              serviceAccountName: controller-manager
+              serviceAccountName: image-based-install-operator
               terminationGracePeriodSeconds: 10
               volumes:
               - emptyDir: {}
@@ -294,7 +294,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: controller-manager
+        serviceAccountName: image-based-install-operator
     strategy: deployment
   installModes:
   - supported: false

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-17T15:23:54Z"
+    createdAt: "2024-09-19T18:20:10Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -59,6 +59,8 @@ spec:
           verbs:
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -111,7 +111,7 @@ spec:
       - name: webhook-certs
         secret:
           secretName: webhook-certs
-      serviceAccountName: controller-manager
+      serviceAccountName: image-based-install-operator
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: leader-election
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: image-based-install-operator
   namespace: image-based-install-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: image-cluster-install-manager
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: image-based-install-operator
   namespace: image-based-install-operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: image-based-install-operator
   namespace: image-based-install-operator

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -115,7 +115,7 @@ const (
 )
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls/finalizers,verbs=update


### PR DESCRIPTION
The write permissions for the configmaps were missed when adding the backup label and is causing errors
labeling in the logs like:

```
time="2024-09-19T12:39:01Z" level=error msg="failed to label ConfigMap target-0/target-0-extras-cm0 for backup" func="github.com/openshift/image-based-install-operator/controllers.(*ImageClusterInstallReconciler).labelReferencedObjectsForBackup" file="/remote-source/app/controllers/imageclusterinstall_controller.go:677" error="configmaps \"target-0-extras-cm0\" is forbidden: User \"system:serviceaccount:multicluster-engine:controller-manager\" cannot patch resource \"configmaps\" in API group \"\" in the namespace \"target-0\"" name=target-0 namespace=target-0
```

Additionally `controller-manager` is too generic a name to be used when IBIO could be deployed into a namespace (`multicluster-engine`) with several other operators.