### PR TITLE
Cleanup & Refactor

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -113,9 +113,6 @@ type ImageClusterInstallStatus struct {
 
 	BareMetalHostRef *BareMetalHostReference `json:"bareMetalHostRef,omitempty"`
 
-	// ConfigurationImageURL is the externally accessible URL for downloading the image containing the SNO configuration
-	ConfigurationImageURL string `json:"configurationImageURL,omitempty"`
-
 	// BootTime indicates the time at which the host was requested to boot. Used to determine install timeouts.
 	BootTime metav1.Time `json:"bootTime,omitempty"`
 }
@@ -132,7 +129,6 @@ type BareMetalHostReference struct {
 // +kubebuilder:resource:path=imageclusterinstalls,shortName=ici
 // +kubebuilder:printcolumn:name="RequirementsMet",type="string",JSONPath=".status.conditions[?(@.type=='RequirementsMet')].reason"
 // +kubebuilder:printcolumn:name="Completed",type="string",JSONPath=".status.conditions[?(@.type=='Completed')].reason"
-// +kubebuilder:printcolumn:name="ConfigurationImageURL",type="string",JSONPath=".status.configurationImageURL"
 // +kubebuilder:printcolumn:name="BareMetalHostRef",type="string",JSONPath=".spec.bareMetalHostRef.name"
 
 // ImageClusterInstall is the Schema for the imageclusterinstall API

--- a/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -25,9 +25,6 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Completed')].reason
       name: Completed
       type: string
-    - jsonPath: .status.configurationImageURL
-      name: ConfigurationImageURL
-      type: string
     - jsonPath: .spec.bareMetalHostRef.name
       name: BareMetalHostRef
       type: string
@@ -347,10 +344,6 @@ spec:
                   - type
                   type: object
                 type: array
-              configurationImageURL:
-                description: ConfigurationImageURL is the externally accessible URL
-                  for downloading the image containing the SNO configuration
-                type: string
               installRestarts:
                 description: InstallRestarts is the total count of container restarts
                   on the clusters install job.

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-19T18:30:51Z"
+    createdAt: "2024-09-22T09:26:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1

--- a/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Completed')].reason
       name: Completed
       type: string
-    - jsonPath: .status.configurationImageURL
-      name: ConfigurationImageURL
-      type: string
     - jsonPath: .spec.bareMetalHostRef.name
       name: BareMetalHostRef
       type: string
@@ -345,10 +342,6 @@ spec:
                   - type
                   type: object
                 type: array
-              configurationImageURL:
-                description: ConfigurationImageURL is the externally accessible URL
-                  for downloading the image containing the SNO configuration
-                type: string
               installRestarts:
                 description: InstallRestarts is the total count of container restarts
                   on the clusters install job.

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -100,7 +100,7 @@ func (r *ImageClusterInstallReconciler) initializeConditions(ctx context.Context
 	return r.Status().Patch(ctx, ici, patch)
 }
 
-func (r *ImageClusterInstallReconciler) setImageReadyCondition(ctx context.Context, ici *v1alpha1.ImageClusterInstall, err error, imageURL string) error {
+func (r *ImageClusterInstallReconciler) setImageReadyCondition(ctx context.Context, ici *v1alpha1.ImageClusterInstall, err error) error {
 	cond := hivev1.ClusterInstallCondition{
 		Type:    hivev1.ClusterInstallRequirementsMet,
 		Status:  corev1.ConditionTrue,
@@ -118,7 +118,6 @@ func (r *ImageClusterInstallReconciler) setImageReadyCondition(ctx context.Conte
 	if updated := setClusterInstallCondition(&ici.Status.Conditions, cond); !updated {
 		return nil
 	}
-	ici.Status.ConfigurationImageURL = imageURL
 	r.Log.Info("Setting image ready condition, status: %s, reason: %s, message: %s", cond.Status, cond.Reason, cond.Message)
 	return r.Status().Patch(ctx, ici, patch)
 }

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -155,7 +155,12 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	if ici.Spec.ClusterDeploymentRef == nil || ici.Spec.ClusterDeploymentRef.Name == "" {
-		log.Error("ClusterDeploymentRef is unset, not reconciling")
+		errorMessagge := fmt.Errorf("clusterDeploymentRef is unset")
+		log.Error(errorMessagge)
+		if updateErr := r.setImageReadyCondition(ctx, ici, errorMessagge, ""); updateErr != nil {
+			log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
+			return ctrl.Result{}, updateErr
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -97,6 +97,7 @@ const (
 	detachedAnnotationValue      = "imageclusterinstall-controller"
 	inspectAnnotation            = "inspect.metal3.io"
 	rebootAnnotation             = "reboot.metal3.io"
+	rebootAnnotationValue        = ""
 	ibioManagedBMH               = "image-based-install-managed"
 	clusterConfigDir             = "cluster-configuration"
 	extraManifestsDir            = "extra-manifests"
@@ -640,7 +641,7 @@ func (r *ImageClusterInstallReconciler) updateBMHProvisioningState(ctx context.C
 		bmh.Spec.Online = true
 		log.Infof("Setting BareMetalHost (%s/%s) spec.Online to true", bmh.Namespace, bmh.Name)
 	}
-	if setAnnotationIfNotExists(&bmh.ObjectMeta, rebootAnnotation, "") {
+	if setAnnotationIfNotExists(&bmh.ObjectMeta, rebootAnnotation, rebootAnnotationValue) {
 		// Reboot host so we will reboot into disk
 		//Note that if the node was powered off the annotation will be removed upon boot (it will not reboot twice).
 		log.Infof("Adding reboot annotations to BareMetalHost (%s/%s)", bmh.Namespace, bmh.Name)
@@ -732,7 +733,7 @@ func (r *ImageClusterInstallReconciler) removeBMHDataImage(ctx context.Context, 
 		dirty = true
 	}
 
-	if setAnnotationIfNotExists(&bmh.ObjectMeta, rebootAnnotation, "") {
+	if setAnnotationIfNotExists(&bmh.ObjectMeta, rebootAnnotation, rebootAnnotationValue) {
 		log.Infof("Adding reboot annotation to BareMetalHost %s/%s", bmh.Namespace, bmh.Name)
 		dirty = true
 	}

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"bytes"
 	"context"
-
 	// These are required for image parsing to work correctly with digest-based pull specs
 	// See: https://github.com/opencontainers/go-digest/blob/v1.0.0/README.md#usage
 	_ "crypto/sha256"
@@ -150,6 +149,11 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	if err := r.initializeConditions(ctx, ici); err != nil {
+		log.Errorf("Failed to initialize conditions: %s", err)
+		return ctrl.Result{}, err
+	}
+
 	if ici.Spec.ClusterDeploymentRef == nil || ici.Spec.ClusterDeploymentRef.Name == "" {
 		log.Error("ClusterDeploymentRef is unset, not reconciling")
 		return ctrl.Result{}, nil
@@ -175,11 +179,6 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 			return ctrl.Result{}, updateErr
 		}
 		return ctrl.Result{Requeue: true}, nil
-	}
-
-	if err := r.initializeConditions(ctx, ici); err != nil {
-		log.Errorf("Failed to initialize conditions: %s", err)
-		return ctrl.Result{}, err
 	}
 
 	if ici.Spec.BareMetalHostRef == nil {

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -591,19 +591,16 @@ func (r *ImageClusterInstallReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Complete(r)
 }
 
-func (r *ImageClusterInstallReconciler) getBmhDataImage(ctx context.Context, log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost) (*bmh_v1alpha1.DataImage, error) {
-	if bmh == nil {
-		return nil, nil
-	}
+func (r *ImageClusterInstallReconciler) getDataImage(ctx context.Context, log logrus.FieldLogger, namespace, name string) (*bmh_v1alpha1.DataImage, error) {
 	dataImage := bmh_v1alpha1.DataImage{}
 	key := client.ObjectKey{
-		Name:      bmh.Name,
-		Namespace: bmh.Namespace,
+		Name:      name,
+		Namespace: namespace,
 	}
 	err := r.Get(ctx, key, &dataImage)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Warnf("Can't find DataImage %s/%s", bmh.Namespace, bmh.Name)
+			log.Warnf("Can't find DataImage %s/%s", namespace, name)
 			return nil, nil
 		}
 		return nil, err
@@ -655,7 +652,7 @@ func (r *ImageClusterInstallReconciler) updateBMHProvisioningState(ctx context.C
 }
 
 func (r *ImageClusterInstallReconciler) createBMHDataImage(ctx context.Context, log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost, url string) error {
-	dataImage, err := r.getBmhDataImage(ctx, log, bmh)
+	dataImage, err := r.getDataImage(ctx, log, bmh.Namespace, bmh.Name)
 	if err != nil {
 		return err
 	}
@@ -1317,7 +1314,7 @@ func (r *ImageClusterInstallReconciler) handleFinalizer(ctx context.Context, log
 			return ctrl.Result{}, true, removeFinalizer()
 		}
 
-		dataImage, err := r.getBmhDataImage(ctx, log, bmh)
+		dataImage, err := r.getDataImage(ctx, log, bmh.Namespace, bmh.Name)
 		if err != nil {
 			return ctrl.Result{}, true, fmt.Errorf("failed to get DataImage: %w", err)
 		}

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -158,7 +158,7 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 	if ici.Spec.ClusterDeploymentRef == nil || ici.Spec.ClusterDeploymentRef.Name == "" {
 		errorMessagge := fmt.Errorf("clusterDeploymentRef is unset")
 		log.Error(errorMessagge)
-		if updateErr := r.setImageReadyCondition(ctx, ici, errorMessagge, ""); updateErr != nil {
+		if updateErr := r.setImageReadyCondition(ctx, ici, errorMessagge); updateErr != nil {
 			log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
 			return ctrl.Result{}, updateErr
 		}
@@ -180,7 +180,7 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 		errorMessagge := fmt.Errorf("clusterDeployment with name '%s' in namespace '%s' not found",
 			cdKey.Name, cdKey.Namespace)
 		log.WithError(err).Error(errorMessagge)
-		if updateErr := r.setImageReadyCondition(ctx, ici, errorMessagge, ""); updateErr != nil {
+		if updateErr := r.setImageReadyCondition(ctx, ici, errorMessagge); updateErr != nil {
 			log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
 			return ctrl.Result{}, updateErr
 		}
@@ -218,7 +218,7 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 	res, _, err := r.writeInputData(ctx, log, ici, clusterDeployment, bmh)
 	if !res.IsZero() || err != nil {
 		if err != nil {
-			if updateErr := r.setImageReadyCondition(ctx, ici, err, ""); updateErr != nil {
+			if updateErr := r.setImageReadyCondition(ctx, ici, err); updateErr != nil {
 				log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
 			}
 			log.Error(err)
@@ -236,7 +236,7 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 	imageUrl, err := url.JoinPath(r.BaseURL, "images", req.Namespace, fmt.Sprintf("%s.iso", ici.ObjectMeta.UID))
 	if err != nil {
 		log.WithError(err).Error("failed to create image url")
-		if updateErr := r.setImageReadyCondition(ctx, ici, err, ""); updateErr != nil {
+		if updateErr := r.setImageReadyCondition(ctx, ici, err); updateErr != nil {
 			log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
 		}
 		return ctrl.Result{}, err
@@ -942,7 +942,7 @@ func (r *ImageClusterInstallReconciler) writeInputData(
 	}
 	if !locked {
 		log.Info("requeueing due to lock contention")
-		if updateErr := r.setImageReadyCondition(ctx, ici, fmt.Errorf("could not acquire lock for image data"), ""); updateErr != nil {
+		if updateErr := r.setImageReadyCondition(ctx, ici, fmt.Errorf("could not acquire lock for image data")); updateErr != nil {
 			log.WithError(updateErr).Error("failed to update ImageClusterInstall status")
 		}
 		return ctrl.Result{RequeueAfter: time.Second * 5}, false, nil

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -1166,6 +1166,12 @@ var _ = Describe("Reconcile", func() {
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(c.Get(ctx, key, clusterInstall)).To(Succeed())
+		cond := findCondition(clusterInstall.Status.Conditions, hivev1.ClusterInstallRequirementsMet)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+		Expect(cond.Message).To(Equal("clusterDeploymentRef is unset"))
+
 	})
 
 	It("sets conditions to show cluster installed when the host can be configured and cluster is ready", func() {


### PR DESCRIPTION
- Since we no longer set the image URL remove ConfigurationImageURL from ICI status
- Disable AutomatedCleaningMode earlier
- Add const for a soft reboot annotation value
- Set RequirementsMet condition in case of missing clusterDeploymentRef
- Initialize conditions prior to other logic