### PR TITLE
ACM-14649: Correct the json field name for extraManifestsRefs

### DIFF
--- a/api/v1alpha1/imageclusterinstall_types.go
+++ b/api/v1alpha1/imageclusterinstall_types.go
@@ -85,7 +85,7 @@ type ImageClusterInstallSpec struct {
 
 	// ExtraManifestsRefs is list of config map references containing additional manifests to be applied to the relocated cluster.
 	// +optional
-	ExtraManifestsRefs []corev1.LocalObjectReference `json:"extraManifestsRef,omitempty"`
+	ExtraManifestsRefs []corev1.LocalObjectReference `json:"extraManifestsRefs,omitempty"`
 
 	// BareMetalHostRef identifies a BareMetalHost object to be used to attach the configuration to the host.
 	// +optional

--- a/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/bundle/manifests/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -164,7 +164,7 @@ spec:
                 - clusterID
                 - infraID
                 type: object
-              extraManifestsRef:
+              extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
                   additional manifests to be applied to the relocated cluster.
                 items:

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-22T09:26:34Z"
+    createdAt: "2024-10-02T17:22:07Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1

--- a/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
@@ -162,7 +162,7 @@ spec:
                 - clusterID
                 - infraID
                 type: object
-              extraManifestsRef:
+              extraManifestsRefs:
                 description: ExtraManifestsRefs is list of config map references containing
                   additional manifests to be applied to the relocated cluster.
                 items:


### PR DESCRIPTION
Previously this was "extraManifestsRef" which was a mistake

Resolves https://issues.redhat.com/browse/ACM-14649