### PR TITLE
MGMT-19033: IBIO OOM while provisioning many clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 COPY vendor/ vendor/
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/manager cmd/manager/main.go
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
+RUN GODEBUG=madvdontneed=1 GOGC=50 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/manager cmd/manager/main.go
+RUN GODEBUG=madvdontneed=1 GOGC=50 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-10-02T17:22:07Z"
+    createdAt: "2024-10-06T09:42:04Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -201,7 +201,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 750Mi
+                    memory: 1500Mi
                   requests:
                     cpu: 10m
                     memory: 250Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,7 +62,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 750Mi
+            memory: 1500Mi
           requests:
             cpu: 10m
             memory: 250Mi


### PR DESCRIPTION
1. Updating memory limit to 1500miB
2. Adding flag for golang garbage collection in order to free memory faster