### PR TITLE
MGMT-19107: Make MachineNetwork required when setting Proxy

### DIFF
--- a/api/v1alpha1/imageclusterinstall_webhook.go
+++ b/api/v1alpha1/imageclusterinstall_webhook.go
@@ -93,6 +93,9 @@ func (r *ImageClusterInstall) validate() error {
 	if err := isValidMachineNetwork(r.Spec.MachineNetwork); err != nil {
 		return fmt.Errorf("invalid machine network: %w", err)
 	}
+	if err := isValidProxy(r.Spec.Proxy, r.Spec.MachineNetwork); err != nil {
+		return fmt.Errorf("invalid proxy: %w", err)
+	}
 	return nil
 }
 
@@ -144,6 +147,13 @@ func isValidMachineNetwork(machineNetwork string) error {
 	_, _, err := net.ParseCIDR(machineNetwork)
 	if err != nil {
 		return fmt.Errorf("error parsing machine network, check that it is valid cidr: %w", err)
+	}
+	return nil
+}
+
+func isValidProxy(proxy *Proxy, machineNetwork string) error {
+	if proxy != nil && machineNetwork == "" {
+		return errors.New("machine network must be set when proxy is defined")
 	}
 	return nil
 }

--- a/api/v1alpha1/imageclusterinstall_webhook_test.go
+++ b/api/v1alpha1/imageclusterinstall_webhook_test.go
@@ -192,6 +192,26 @@ var _ = Describe("ValidateUpdate", func() {
 		Expect(err.Error()).To(ContainSubstring("invalid machine network"))
 	})
 
+	It("create fail when proxy is invalid", func() {
+		newClusterInstall := &ImageClusterInstall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config",
+				Namespace: "test-namespace",
+			},
+			Spec: ImageClusterInstallSpec{
+				Proxy: &Proxy{
+					HTTPProxy:  "http://proxy.com:3128",
+					HTTPSProxy: "http://proxy.com:3128",
+					NoProxy:    "noproxy.com",
+				},
+			},
+		}
+
+		warns, err := newClusterInstall.ValidateCreate()
+		Expect(warns).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("invalid proxy"))
+	})
+
 	It("update succeeds BMH ref update while image isn't ready", func() {
 		oldClusterInstall := &ImageClusterInstall{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Installation always fails when MachineNetwork is not set and Proxy is set, so it's best to reject the creation of the ICI in the first place.

closes [MGMT-19107](https://issues.redhat.com//browse/MGMT-19107)