### PR TITLE
MGMT-19206: installer should save seed reconfiguration file when creating the iso

### DIFF
--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -831,6 +831,11 @@ func (r *ImageClusterInstallReconciler) ensureCreds(ctx context.Context, log log
 	if err := r.Credentials.EnsureKubeconfigSecret(ctx, log, cd, filepath.Join(workDir, authDir, credentials.Kubeconfig)); err != nil {
 		return fmt.Errorf("failed to ensure kubeconfig secret: %w", err)
 	}
+
+	if err := r.Credentials.EnsureSeedReconfigurationSecret(ctx, log, cd, filepath.Join(workDir, ClusterConfigDir, credentials.SeedReconfigurationFileName)); err != nil {
+		return fmt.Errorf("failed to ensure seed reconfiguration secret %w", err)
+	}
+
 	return nil
 }
 
@@ -1183,7 +1188,8 @@ func fileExists(path string) bool {
 func verifyIsoAndAuthExists(clusterConfigPath string) bool {
 	for _, file := range []string{filepath.Join(clusterConfigPath, IsoName),
 		filepath.Join(clusterConfigPath, authDir, kubeAdminFile),
-		filepath.Join(clusterConfigPath, authDir, credentials.Kubeconfig)} {
+		filepath.Join(clusterConfigPath, authDir, credentials.Kubeconfig),
+		filepath.Join(clusterConfigPath, ClusterConfigDir, credentials.SeedReconfigurationFileName)} {
 		if !fileExists(file) {
 			return false
 		}

--- a/controllers/imageclusterinstall_controller_test.go
+++ b/controllers/imageclusterinstall_controller_test.go
@@ -257,8 +257,10 @@ var _ = Describe("Reconcile", func() {
 			Return(nil).Times(1).Do(func(any, any, any) {
 			Expect(os.WriteFile(outputFilePath(ClusterConfigDir, IsoName), []byte("test"), 0644)).To(Succeed())
 			Expect(os.MkdirAll(outputFilePath(ClusterConfigDir, authDir), 0700)).To(Succeed())
+			Expect(os.MkdirAll(outputFilePath(ClusterConfigDir, ClusterConfigDir), 0700)).To(Succeed())
 			Expect(os.WriteFile(outputFilePath(ClusterConfigDir, authDir, kubeAdminFile), []byte("test"), 0644)).To(Succeed())
 			Expect(os.WriteFile(outputFilePath(ClusterConfigDir, authDir, credentials.Kubeconfig), []byte(kubeconfig), 0644)).To(Succeed())
+			Expect(os.WriteFile(outputFilePath(ClusterConfigDir, ClusterConfigDir, credentials.SeedReconfigurationFileName), []byte("test"), 0644)).To(Succeed())
 		})
 	}
 
@@ -1459,6 +1461,9 @@ var _ = Describe("Reconcile with DataImageCoolDownPeriod set to 1 second", func(
 			Expect(os.MkdirAll(filepath.Join(dir, ClusterConfigDir, authDir), 0700)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(dir, ClusterConfigDir, authDir, kubeAdminFile), []byte("test"), 0644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(dir, ClusterConfigDir, authDir, credentials.Kubeconfig), []byte(kubeconfig), 0644)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(dir, ClusterConfigDir, ClusterConfigDir), 0700)).To(Succeed())
+
+			Expect(os.WriteFile(filepath.Join(dir, ClusterConfigDir, ClusterConfigDir, credentials.SeedReconfigurationFileName), []byte("test"), 0644)).To(Succeed())
 		})
 	}
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -42,7 +42,9 @@ func (i *installer) CreateInstallationIso(ctx context.Context, log logrus.FieldL
 	assets := []asset.WritableAsset{
 		&configimage.ConfigImage{},
 		&kubeconfig.ImageBasedAdminClient{},
-		&password.KubeadminPassword{}}
+		&password.KubeadminPassword{},
+		&configimage.ClusterConfiguration{},
+	}
 	fetcher := assetStore.NewAssetsFetcher(workDir)
 	return fetcher.FetchAndPersist(ctx, assets)
 }


### PR DESCRIPTION
[MGMT-19206](https://issues.redhat.com//browse/MGMT-19206): installer should save seed reconfiguration file when creating the iso
It will be saved as inside working folder as cluster-configuration/manifest.json
New secret will be created with it's data