### PR TITLE
NO-ISSUE: Add CA bundle to install-config only when non empty

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -96,10 +96,9 @@ func WriteInstallConfig(
 			Replicas: swag.Int64(0),
 			Name:     "worker",
 		}},
-		PullSecret:            psData,
-		Proxy:                 proxy(ici.Spec.Proxy),
-		AdditionalTrustBundle: caBundle,
-		Platform:              installertypes.Platform{None: &none.Platform{}},
+		PullSecret: psData,
+		Proxy:      proxy(ici.Spec.Proxy),
+		Platform:   installertypes.Platform{None: &none.Platform{}},
 	}
 	if caBundle != "" {
 		installConfig.AdditionalTrustBundle = caBundle


### PR DESCRIPTION
This PR skips adding an empty CA bundle in the install-config, just for code readability/consistency, as later on we check if there is a non empty `caBundle`. 

PS. As far as I tested via the `openshift-install`, providing an empty `additionalTrustBundle` does not lead to any issues, it is just omitted. So that's purely a source code readability/maintainability change.