### PR TITLE
MGMT-19268: IBIO stops serving dataimages to clusters

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
@@ -39,6 +40,7 @@ func main() {
 		Log:        log,
 		WorkDir:    workDir,
 		ConfigsDir: filepath.Join(Options.DataDir, "namespaces"),
+		Mu:         sync.Mutex{},
 	}
 	http.Handle("/images/", s)
 	server := &http.Server{

--- a/internal/imageserver/imageserver.go
+++ b/internal/imageserver/imageserver.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/diskfs/go-diskfs"
 	"github.com/diskfs/go-diskfs/disk"
@@ -23,6 +24,7 @@ type Handler struct {
 	Log        logrus.FieldLogger
 	WorkDir    string
 	ConfigsDir string
+	Mu         sync.Mutex
 }
 
 var pathRegexp = regexp.MustCompile(`^/images/(.+)/(.+)\.iso$`)
@@ -53,7 +55,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// if anything fails remove the workdir, if create succeeds it will remove the workdir so this will be a noop
-	defer os.RemoveAll(isoWorkDir)
+	defer func() {
+		os.RemoveAll(isoWorkDir)
+	}()
 
 	// TODO: improve this to wait for some timout (use ctx?) instead of erroring on a lock failure immediately
 	locked, lockErr, funcErr := filelock.WithReadLock(configDir, func() error {
@@ -65,7 +69,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if funcErr != nil {
-		h.Log.WithError(funcErr).Error("failed to acquire file lock")
+		h.Log.WithError(funcErr).Error("failed to acquire copy config dir")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -74,20 +78,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
 	outPath, err := tempFileName(h.WorkDir)
 	if err != nil {
 		h.Log.WithError(err).Error("failed to create iso output file")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if err := create(outPath, isoWorkDir, lca_api.BlockDeviceLabel); err != nil {
-		h.Log.WithError(err).Error("failed to create iso")
+	defer func() {
+		os.Remove(outPath)
+	}()
+
+	if err = h.create(outPath, isoWorkDir, lca_api.BlockDeviceLabel, h.Log); err != nil {
+		h.Log.WithError(err).Errorf("failed to create ISO, outPath: %s, isoWorkDir: %s", outPath, isoWorkDir)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	defer os.Remove(outPath)
-
 	http.ServeFile(w, r, outPath)
 }
 
@@ -109,13 +114,13 @@ func copyDir(dst, src string) error {
 		}
 		defer dest.Close()
 
-		src, err := os.Open(path)
+		srcfile, err := os.Open(path)
 		if err != nil {
 			return err
 		}
-		defer src.Close()
+		defer srcfile.Close()
 
-		_, err = io.Copy(dest, src)
+		_, err = io.Copy(dest, srcfile)
 		return err
 	})
 }
@@ -135,7 +140,11 @@ func tempFileName(dir string) (string, error) {
 }
 
 // create builds an iso file at outPath with the given volumeLabel using the contents of the working directory
-func create(outPath string, workDir string, volumeLabel string) error {
+func (h *Handler) create(outPath string, workDir string, volumeLabel string, log logrus.FieldLogger) error {
+	// Block concurrent ISO creation.
+	h.Mu.Lock()
+	defer h.Mu.Unlock()
+
 	if err := os.MkdirAll(filepath.Dir(outPath), 0700); err != nil {
 		return err
 	}

--- a/internal/imageserver/imageserver_test.go
+++ b/internal/imageserver/imageserver_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/diskfs/go-diskfs"
@@ -49,6 +50,7 @@ var _ = Describe("ServeHttp", func() {
 			Log:        logrus.New(),
 			WorkDir:    workDir,
 			ConfigsDir: configsDir,
+			Mu:         sync.Mutex{},
 		}
 		server = httptest.NewServer(s)
 		client = server.Client()


### PR DESCRIPTION
Solves: IBIO stops serving dataimages to clusters deploying - failed to create iso - error walking tree: could not get pwd: getwd: no such file or directory

Although the image server is using different `workdirs` and different `outPath`, there seems to be a race condition in the create ISO process that results in a corrupted filesystem and missing/inconsistent files or directories. This change ensures that the filesystem creation and finalization operations are not executed concurrently across multiple goroutines, preventing potential data corruption.


### Note: this change isn't relevant for the main branch since this code no longer exists in that codebase
