### PR TITLE
MGMT-19341: IBIO isn't creating the config after restart for ICI with bootTime set

### DIFF
--- a/internal/imageserver/imageserver.go
+++ b/internal/imageserver/imageserver.go
@@ -30,7 +30,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace := match[1]
 	name := match[2]
 	h.Log.Infof("Serving image for ImageClusterInstall %s/%s", namespace, name)
-	outPath := filepath.Join(h.ConfigsDir, namespace, name, controllers.FilesDir, controllers.ClusterConfigDir, controllers.IsoName)
+	outPath := filepath.Join(controllers.GetClusterConfigDir(h.ConfigsDir, namespace, name), controllers.IsoName)
 	if _, err := os.Stat(outPath); err != nil {
 		h.Log.WithError(err).Error("failed to find iso file")
 		http.NotFound(w, r)


### PR DESCRIPTION
Make sure the clusterInfo file exists in case the bootTime is set
This would ensure the clusterInfo is regenerated in case the IBIO pod was restarted