### PR TITLE
MGMT-19268: IBIO stops serving dataimages to clusters deploying - fai…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
@@ -39,6 +40,7 @@ func main() {
 		Log:        log,
 		WorkDir:    workDir,
 		ConfigsDir: filepath.Join(Options.DataDir, "namespaces"),
+		Mu:         sync.Mutex{},
 	}
 	http.Handle("/images/", s)
 	server := &http.Server{

--- a/internal/imageserver/imageserver_test.go
+++ b/internal/imageserver/imageserver_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/diskfs/go-diskfs"
@@ -49,6 +50,7 @@ var _ = Describe("ServeHttp", func() {
 			Log:        logrus.New(),
 			WorkDir:    workDir,
 			ConfigsDir: configsDir,
+			Mu:         sync.Mutex{},
 		}
 		server = httptest.NewServer(s)
 		client = server.Client()


### PR DESCRIPTION
…led to create iso - error walking tree: could not get pwd: getwd: no such file or directory

Although the image server is using diffrent workdirs and diffrent outPath there seems to be a race condition in the create ISO that results a currpteed filesystem and missing/inconsistent files or directories. This change ensures that the filesystem creation and finalization operations are not executed concurrently across multiple goroutines, preventing potential data corruption.