### PR TITLE
MGMT-19492: Add siteconfig secret label

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -190,9 +190,9 @@ func (r *Credentials) createOrUpdateClusterCredentialSecret(ctx context.Context,
 			BlockOwnerDeletion: ptr.To(true),
 		}}
 
-		secret.Labels = addLabel(secret.Labels, "hive.openshift.io/cluster-deployment-name", cd.Name)
-		secret.Labels = addLabel(secret.Labels, "hive.openshift.io/secret-type", secretType)
-		secret.Labels = addLabel(secret.Labels, SecretResourceLabel, SecretResourceValue)
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, "hive.openshift.io/cluster-deployment-name", cd.Name)
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, "hive.openshift.io/secret-type", secretType)
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, SecretResourceLabel, SecretResourceValue)
 
 		// Update the Secret object with the desired data
 		secret.Data = data
@@ -257,16 +257,4 @@ func (r *Credentials) ClusterIdentitySecrets(ctx context.Context, cd *hivev1.Clu
 	}
 
 	return idData, true, nil
-}
-
-func addLabel(labels map[string]string, labelKey, labelValue string) map[string]string {
-	if labelKey == "" {
-		// Don't need to add a label.
-		return labels
-	}
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[labelKey] = labelValue
-	return labels
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -30,6 +30,9 @@ const (
 	kubeadmincreds              = "kubeadmincreds"
 	kubeAdminKey                = "password"
 	SeedReconfigurationFileName = "manifest.json"
+
+	secretPreservationLabel = "siteconfig.open-cluster-management.io/preserve"
+	secretPreservationValue = "cluster-identity"
 )
 
 //go:generate mockgen --build_flags=--mod=mod -package=credentials -destination=mock_client.go sigs.k8s.io/controller-runtime/pkg/client Client
@@ -193,6 +196,7 @@ func (r *Credentials) createOrUpdateClusterCredentialSecret(ctx context.Context,
 		metav1.SetMetaDataLabel(&secret.ObjectMeta, "hive.openshift.io/cluster-deployment-name", cd.Name)
 		metav1.SetMetaDataLabel(&secret.ObjectMeta, "hive.openshift.io/secret-type", secretType)
 		metav1.SetMetaDataLabel(&secret.ObjectMeta, SecretResourceLabel, SecretResourceValue)
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, secretPreservationLabel, secretPreservationValue)
 
 		// Update the Secret object with the desired data
 		secret.Data = data


### PR DESCRIPTION
This ensures that the siteconfig operator will backup and restore these secrets when it is orchestrating a reinstall for IBBF

Resolves https://issues.redhat.com/browse/MGMT-19492

Additionally this PR moves the labels and owner references to the mutate function in `createOrUpdateClusterCredentialSecret` so that we can ensure those are always set.