### PR TITLE
MGMT-19745: Handle readOnlyRootFilesystem in pod deployments

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,6 +47,8 @@ spec:
           value: "https"
         - name: MAX_CONCURRENT_RECONCILES
           value: "1"
+        - name: TMPDIR
+          value: /data
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app: image-based-install-operator
     spec:
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -49,6 +52,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +94,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          privileged: false
+          readOnlyRootFilesystem: true
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
MCE's installer is adding additional security features to our deployment when it is run.
We should also add those to our deployment here to catch any issues they might cause in presubmits rather than only hitting them when QE gets a build from MCE.

Specifically the addition of readOnlyRootFilesystem caused https://issues.redhat.com/browse/MGMT-19745. This would have been found in a presubmit if it was here before the relevant changes were made.

Also sets TMPDIR env var to /data. Some dependencies (openshift/installer) also use temp storage so it's better to set TMPDIR for the whole process rather than trying to enforce temp files be written to /data in code.