### PR TITLE
[backplane-2.7] MGMT-19977: Rename webhook service

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -110,7 +110,7 @@ spec:
           secretName: ibi-config-serving-certs
       - name: webhook-certs
         secret:
-          secretName: webhook-certs
+          secretName: ibi-webhook-serving-certs
       serviceAccountName: image-based-install-operator
       terminationGracePeriodSeconds: 10
 ---

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,7 +10,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: image-based-install-webhook
       namespace: system
       path: /validate-extensions-hive-openshift-io-v1alpha1-imageclusterinstall
   failurePolicy: Fail

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: webhook-service
+  name: image-based-install-webhook
   namespace: system
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webhook-certs
+    service.beta.openshift.io/serving-cert-secret-name: ibi-webhook-serving-certs
 spec:
   ports:
   - port: 443


### PR DESCRIPTION
Move away from the default name to avoid name colisions when being deployed in the same namespace as other services

https://issues.redhat.com/browse/MGMT-19977