### PR TITLE
MGMT-20128: Image based install operator not reconciling after pod is  restarted

### DIFF
--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -165,7 +165,7 @@ func installationTimedout(ici *v1alpha1.ImageClusterInstall) bool {
 	return cond != nil && cond.Status == corev1.ConditionTrue && cond.Reason == v1alpha1.InstallTimedoutReason
 }
 
-func installationCompleted(ici *v1alpha1.ImageClusterInstall) bool {
+func InstallationCompleted(ici *v1alpha1.ImageClusterInstall) bool {
 	cond := findCondition(ici.Status.Conditions, hivev1.ClusterInstallCompleted)
 	return cond != nil && cond.Status == corev1.ConditionTrue
 }

--- a/controllers/imageclusterinstall_controller.go
+++ b/controllers/imageclusterinstall_controller.go
@@ -143,7 +143,7 @@ func (r *ImageClusterInstallReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	// Nothing to do if the installation is complete
-	if installationCompleted(ici) {
+	if InstallationCompleted(ici) {
 		return ctrl.Result{}, nil
 	}
 	// Nothing to do if the installation process started and the config.iso exists

--- a/controllers/imageclusterinstall_monitor.go
+++ b/controllers/imageclusterinstall_monitor.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-
 	// These are required for image parsing to work correctly with digest-based pull specs
 	// See: https://github.com/opencontainers/go-digest/blob/v1.0.0/README.md#usage
 	_ "crypto/sha256"
@@ -74,7 +73,7 @@ func (r *ImageClusterInstallMonitor) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 	// Nothing to do if the installation process has already stopped
-	if installationCompleted(ici) {
+	if InstallationCompleted(ici) {
 		log.Infof("Cluster %s/%s finished installation process, nothing to do", ici.Namespace, ici.Name)
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
The monitor will list existing ImageClusterInstall CRs and call client.Status.Update for all ICI that didn't complete the installation.
This should enqueue the ICI CRs for reconciliation when the controller starts