### PR TITLE
MGMT-21758: Update konflux dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.24 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Changes from https://github.com/openshift/image-based-install-operator/commit/5ee89af3803f276669a99e7c4af033d1f9e5baad need to be pulled into the konflux dockerfile.

cc @danmanor 