### PR TITLE
MGMT-21853: Change binary paths to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as 
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /workspace
+WORKDIR /opt/app-root/src
+
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
@@ -14,19 +15,17 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 COPY vendor/ vendor/
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/manager/main.go
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o server cmd/server/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/manager cmd/manager/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
-
-#RUN microdnf install glibc-devel
 
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR
 
 WORKDIR /
-COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/server .
+COPY --from=builder /opt/app-root/src/build/manager /usr/local/bin/
+COPY --from=builder /opt/app-root/src/build/server /usr/local/bin/
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-15T16:31:43Z"
+    createdAt: "2025-09-25T15:08:24Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: image-based-install-operator.v0.0.1
@@ -160,7 +160,7 @@ spec:
               - args:
                 - --leader-elect
                 command:
-                - /manager
+                - /usr/local/bin/manager
                 env:
                 - name: ROUTE_NAMESPACE
                   valueFrom:
@@ -204,7 +204,7 @@ spec:
                 - mountPath: /webhook-certs
                   name: webhook-certs
               - command:
-                - /server
+                - /usr/local/bin/server
                 env:
                 - name: HTTPS_KEY_FILE
                   value: /certs/tls.key

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /usr/local/bin/manager
         args:
         - --leader-elect
         image: controller:latest
@@ -72,7 +72,7 @@ spec:
         - name: webhook-certs
           mountPath: /webhook-certs
       - command:
-        - /server
+        - /usr/local/bin/server
         image: controller:latest
         name: server
         env:


### PR DESCRIPTION
Without this the deployment with konflux images was failing with:

```
Error: container create failed: time="2025-09-24T13:24:55Z" level=error msg="runc create failed: unable to start container process: exec: \"/server\": stat /server: no such file or directory"
Error: container create failed: time="2025-09-24T13:24:55Z" level=error msg="runc create failed: unable to start container process: exec: \"/manager\": stat /manager: no such file or directory"
```
    
Resolves https://issues.redhat.com/browse/MGMT-21853
