### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for image-based-install-operator-mce-29

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -22,7 +22,8 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 ENV SUMMARY="The image-based-install-operator orchestrates image-based cluster installs from a central cluster using declarative APIs" \
     DESCRIPTION="The image-based-install operator creates the configuration ISO for image-based cluster installation and attaches that image to hosts using a BareMetalHost definition"
 
-LABEL name="image-based-install-operator" \
+LABEL name="multicluster-engine/image-based-install-rhel9" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       com.redhat.component="image-based-install-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
