### PR TITLE
ACM-33186: Revert Renovate configuration for Hive updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,29 +9,11 @@
     "prConcurrentLimit": 0,
     "enabledManagers": [
         "custom.regex",
-        "tekton",
-        "gomod"
+        "tekton"
     ],
     "tekton": {
         "managerFilePatterns": [
             "/^.tekton/*/"
-        ]
-    },
-    "gomod": {
-        "postUpdateOptions": [
-            "gomodUpdateImportPaths",
-            "gomodTidy"
-        ],
-        "packageRules": [
-            {
-                "matchManagers": [
-                    "gomod"
-                ],
-                "matchDepTypes": [
-                    "indirect"
-                ],
-                "enabled": false
-            }
         ]
     },
     "customManagers": [
@@ -80,26 +62,6 @@
                 "registry.access.redhat.com/ubi9/ubi-minimal"
             ],
             "enabled": false
-        },
-        {
-            "matchManagers": [
-                "gomod"
-            ],
-            "enabled": false
-        },
-        {
-            "matchManagers": [
-                "gomod"
-            ],
-            "matchPackageNames": [
-                "github.com/openshift/hive/apis"
-            ],
-            "groupName": "Hive API Synchronization",
-            "addLabels": [
-                "hive-api",
-                "api-sync"
-            ],
-            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
Revert the Renovate/MintMaker configuration that enables hive/apis digest tracking.
MintMaker generates bare commit hashes instead of proper Go pseudo-versions,
which breaks go.mod.

Reverts changes from [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.