### PR TITLE
NO-ISSUE: Update github.com/openshift/hive/apis digest to 6c66e20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.39.0
 	github.com/openshift/api v0.0.0-20251120220512-cb382c9eaf42
 	github.com/openshift/assisted-service/api v0.0.0
-	github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57
+	github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 	github.com/openshift/installer v1.4.21-rc2
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,8 @@ github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581 h1:YWom
 github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d h1:iQfTKBmMcwFTxxVWV7U/C6GqgIIWTKD8l5HXslvn53s=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57 h1:Jk9HVqFTkNNxCB4gaCMaDH4bAYsPuFTwbiPGJy2bKg4=
-github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57/go.mod h1:20tnfMYPSXqVDypUaO2vmxOtFzWj5l2KdZ+zYENpycI=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 h1:R8iA8JQ4k+2dNgseiFoLe3UkokexpUQTNHHb05UIuR4=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
 github.com/openshift/installer v1.4.21-rc2 h1:KHTw3O/fXRA3H5p2ZK7vu3HcPmdxYuUbCdByx3DB7tw=
 github.com/openshift/installer v1.4.21-rc2/go.mod h1:3ATaLOa+jMDvA30gkrTskppvkggXmtKHtMWQ1Sog6kA=
 github.com/openshift/library-go v0.0.0-20251107090138-0de9712313a5 h1:Gq8jCFgSrilZ2ZHjQleFZWlblikc1aaRZ0hqs+yvrP4=

--- a/vendor/github.com/openshift/hive/apis/hive/v1/syncidentityprovider_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/syncidentityprovider_types.go
@@ -19,7 +19,7 @@ type SyncIdentityProviderCommonSpec struct {
 type SelectorSyncIdentityProviderSpec struct {
 	SyncIdentityProviderCommonSpec `json:",inline"`
 
-	// ClusterDeploymentSelector is a LabelSelector indicating which clusters the SelectorIdentityProvider
+	// ClusterDeploymentSelector is a LabelSelector indicating which clusters the SelectorSyncIdentityProvider
 	// applies to in any namespace.
 	// +optional
 	ClusterDeploymentSelector metav1.LabelSelector `json:"clusterDeploymentSelector,omitempty"`
@@ -32,12 +32,12 @@ type SyncIdentityProviderSpec struct {
 	SyncIdentityProviderCommonSpec `json:",inline"`
 
 	// ClusterDeploymentRefs is the list of LocalObjectReference indicating which clusters the
-	// SyncSet applies to in the SyncSet's namespace.
+	// SyncIdentityProvider applies to in the SyncIdentityProvider's namespace.
 	// +required
 	ClusterDeploymentRefs []corev1.LocalObjectReference `json:"clusterDeploymentRefs"`
 }
 
-// IdentityProviderStatus defines the observed state of SyncSet
+// IdentityProviderStatus defines the observed state of the SyncIdentityProvider
 type IdentityProviderStatus struct {
 }
 
@@ -45,7 +45,7 @@ type IdentityProviderStatus struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// SelectorSyncIdentityProvider is the Schema for the SelectorSyncSet API
+// SelectorSyncIdentityProvider is the Schema for the SelectorSyncIdentityProvider API
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
 type SelectorSyncIdentityProvider struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1240,7 +1240,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/hive/apis v0.0.0-20260127213836-e33d70397d57
+# github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 ## explicit; go 1.24.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
Update github.com/openshift/hive/apis with proper Go pseudo-version.

See [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to maintain system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->