### PR TITLE
NO-ISSUE: Create Konflux Pipelines for branch (backplane-5.0)

### DIFF
--- a/.tekton/image-based-install-operator-mce-50-pull-request.yaml
+++ b/.tekton/image-based-install-operator-mce-50-pull-request.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/image-based-install-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "backplane-5.0"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: release-mce-50
+    appstudio.openshift.io/component: image-based-install-operator-mce-50
+    pipelines.appstudio.openshift.io/type: build
+  name: image-based-install-operator-mce-50-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/image-based-install-operator-mce-50:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
+    - name: dockerfile
+      value: Dockerfile.konflux
+    - name: path-context
+      value: .
+    - name: build-source-image
+      value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-image-based-install-operator-mce-50
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/image-based-install-operator-mce-50-push.yaml
+++ b/.tekton/image-based-install-operator-mce-50-push.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/image-based-install-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "backplane-5.0"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: release-mce-50
+    appstudio.openshift.io/component: image-based-install-operator-mce-50
+    pipelines.appstudio.openshift.io/type: build
+  name: image-based-install-operator-mce-50-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/image-based-install-operator-mce-50:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/ppc64le
+        - linux/s390x
+        - linux/arm64
+    - name: dockerfile
+      value: Dockerfile.konflux
+    - name: path-context
+      value: .
+    - name: build-source-image
+      value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-image-based-install-operator-mce-50
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,53 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /opt/app-root/src
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY api/ api/
+COPY controllers/ controllers/
+COPY internal/ internal/
+COPY vendor/ vendor/
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/manager cmd/manager/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
+
+FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+
+ENV SUMMARY="The image-based-install-operator orchestrates image-based cluster installs from a central cluster using declarative APIs" \
+    DESCRIPTION="The image-based-install operator creates the configuration ISO for image-based cluster installation and attaches that image to hosts using a BareMetalHost definition"
+
+ARG version=5.0
+
+LABEL name="multicluster-engine/image-based-install-rhel9" \
+      cpe="cpe:/a:redhat:multicluster_engine:5.0::el9" \
+      summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      com.redhat.component="image-based-install-operator" \
+      io.k8s.display-name="Image Based Install Operator" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.openshift.tags="install,cluster,provisioning" \
+      distribution-scope="public" \
+      release="${version}" \
+      version="${version}" \
+      url="https://github.com/openshift/image-based-install-operator" \
+      vendor="Red Hat, Inc."
+
+ARG DATA_DIR=/data
+RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR
+
+RUN dnf install -y nmstate-libs nmstate && dnf clean all && rm -rf /var/cache/dnf/*
+
+WORKDIR /
+COPY --from=builder /opt/app-root/src/build/manager /usr/local/bin/
+COPY --from=builder /opt/app-root/src/build/server /usr/local/bin/
+USER 65532:65532
+ENV GODEBUG=madvdontneed=1
+ENV GOGC=50
+
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,10 @@
+contentOrigin:
+  repofiles: ["./redhat.repo"]
+packages:
+  - nmstate
+  - nmstate-libs
+arches:
+  - aarch64
+  - x86_64
+  - ppc64le
+  - s390x

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,104 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+  - arch: aarch64
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmstate-2.2.45-1.el9_6.aarch64.rpm
+        repoid: rhel-9-for-aarch64-appstream-rpms
+        size: 3946432
+        checksum: sha256:0d4ecf3788a2a430d5166e1da71dbbaa93106f8e7c8fadacc9b415c6cc0d136f
+        name: nmstate
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmstate-libs-2.2.45-1.el9_6.aarch64.rpm
+        repoid: rhel-9-for-aarch64-appstream-rpms
+        size: 3079491
+        checksum: sha256:6fed6addf82b89bdbd8c4aeb3921c7faad9eb4aedad003985c7bc06d27a54323
+        name: nmstate-libs
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/n/NetworkManager-config-server-1.52.0-4.el9_6.noarch.rpm
+        repoid: rhel-9-for-aarch64-baseos-rpms
+        size: 9685
+        checksum: sha256:5b431a020d9aef324c0d8578aec6bd8b6c94e5636f653623866575206f150f7a
+        name: NetworkManager-config-server
+        evr: 1:1.52.0-4.el9_6
+        sourcerpm: NetworkManager-1.52.0-4.el9_6.src.rpm
+    source: []
+    module_metadata: []
+  - arch: ppc64le
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmstate-2.2.45-1.el9_6.ppc64le.rpm
+        repoid: rhel-9-for-ppc64le-appstream-rpms
+        size: 4132771
+        checksum: sha256:4022112702f55516fe11963a19ccc1ff679044080bd12f374fa3e56c9b16aeb3
+        name: nmstate
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmstate-libs-2.2.45-1.el9_6.ppc64le.rpm
+        repoid: rhel-9-for-ppc64le-appstream-rpms
+        size: 3235456
+        checksum: sha256:52ddb47f7334e260d53ed395f0966a6f25c1c49e05638f9014c8d1045a066227
+        name: nmstate-libs
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/n/NetworkManager-config-server-1.52.0-4.el9_6.noarch.rpm
+        repoid: rhel-9-for-ppc64le-baseos-rpms
+        size: 9685
+        checksum: sha256:5b431a020d9aef324c0d8578aec6bd8b6c94e5636f653623866575206f150f7a
+        name: NetworkManager-config-server
+        evr: 1:1.52.0-4.el9_6
+        sourcerpm: NetworkManager-1.52.0-4.el9_6.src.rpm
+    source: []
+    module_metadata: []
+  - arch: s390x
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmstate-2.2.45-1.el9_6.s390x.rpm
+        repoid: rhel-9-for-s390x-appstream-rpms
+        size: 4998102
+        checksum: sha256:ef84bee35bcec8d3bc795d704a42371d9b70b37cae2a86d6dd537b8b7e61cbc7
+        name: nmstate
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmstate-libs-2.2.45-1.el9_6.s390x.rpm
+        repoid: rhel-9-for-s390x-appstream-rpms
+        size: 3846461
+        checksum: sha256:abf4a3a559a769c4d7f732402a50966789715d908cf5367d03d572fb487f4f64
+        name: nmstate-libs
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/n/NetworkManager-config-server-1.52.0-4.el9_6.noarch.rpm
+        repoid: rhel-9-for-s390x-baseos-rpms
+        size: 9685
+        checksum: sha256:5b431a020d9aef324c0d8578aec6bd8b6c94e5636f653623866575206f150f7a
+        name: NetworkManager-config-server
+        evr: 1:1.52.0-4.el9_6
+        sourcerpm: NetworkManager-1.52.0-4.el9_6.src.rpm
+    source: []
+    module_metadata: []
+  - arch: x86_64
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmstate-2.2.45-1.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-rpms
+        size: 4173611
+        checksum: sha256:9618fb746efee42c56278900c3ded88f4d420edbe50041d1db9e3e75cb89a8cc
+        name: nmstate
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmstate-libs-2.2.45-1.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-rpms
+        size: 3258256
+        checksum: sha256:d2a367f6d37305680137e694472b31e8c41cedc7e4a1c5a06643cb616e9aa8b2
+        name: nmstate-libs
+        evr: 2.2.45-1.el9_6
+        sourcerpm: nmstate-2.2.45-1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/NetworkManager-config-server-1.52.0-4.el9_6.noarch.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 9685
+        checksum: sha256:5b431a020d9aef324c0d8578aec6bd8b6c94e5636f653623866575206f150f7a
+        name: NetworkManager-config-server
+        evr: 1:1.52.0-4.el9_6
+        sourcerpm: NetworkManager-1.52.0-4.el9_6.src.rpm
+    source: []
+    module_metadata: []


### PR DESCRIPTION
Add Konflux build configuration for backplane-5.0

This PR adds the necessary Konflux pipeline configuration files to support the new backplane-5.0 branch.

Changes include:
- Add Tekton pipeline definitions for pull requests and pushes
- Add Dockerfile.konflux for Konflux builds (if not exists)
- Add rpms configuration files for dependency management (if not exists)
- Update version references from MCE 2.17 to 5.0

Based on configuration from origin/backplane-2.17.

/cc @carbonin @gamli75
