### PR TITLE
NO-ISSUE: Update renovate to prevent PRs to backplane-5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bu
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o build/server cmd/server/main.go
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
 
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,16 @@
         "lgtm",
         "approved"
     ],
+    "baseBranchPatterns": [
+        "main",
+        "backplane-2.6",
+        "backplane-2.7",
+        "backplane-2.8",
+        "backplane-2.9",
+        "backplane-2.10",
+        "backplane-2.11",
+        "backplane-2.17"
+    ],
     "prHourlyLimit": 0,
     "prConcurrentLimit": 0,
     "enabledManagers": [


### PR DESCRIPTION
We want to fast forward to backplane-5.0, so we want to prevent PRs from konflux to backplane-5.0.
Also included a manual cherry pick of 7b19bc4e5be688c7c9cc5ec95835e7b362eecdd7 since it's already merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base container image to the latest stable version.
  * Configured build automation to target specific release branches for controlled dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->