### PR TITLE
MGMT-24455: upgrade to golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/image-based-install-operator
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/containers/image/v5 v5.31.0

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="2.8.0"
+VERSION="2.11.4"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2
- Bump golangci-lint from v2.8.0 to v2.11.4

https://redhat.atlassian.net/browse/MGMT-24455