### PR TITLE
ACM-31164: Test and validate network policies for Image Based components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,9 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	cp bundle/manifests/image-based-install-operator.clusterserviceversion.yaml config/manifests/bundle-overrides/csv.yaml
+	$(KUSTOMIZE) build config/manifests/bundle-overrides -o bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+	rm config/manifests/bundle-overrides/csv.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-29T12:29:20Z"
+    createdAt: ""
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: image-based-install-operator.v0.0.1

--- a/bundle/manifests/image-based-install-operator_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/image-based-install-operator_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: image-based-install-operator
+  name: image-based-install-operator
+spec:
+  egress:
+  - ports:
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+  - ports:
+    - port: 6443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    - ipBlock:
+        cidr: ::/0
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - port: 8080
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  - ports:
+    - port: 8000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: image-based-install-operator
+  policyTypes:
+  - Ingress
+  - Egress

--- a/config/manager/image-based-install-operator-networkpolicy.yaml
+++ b/config/manager/image-based-install-operator-networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: image-based-install-operator
+  labels:
+    app: image-based-install-operator
+spec:
+  podSelector:
+    matchLabels:
+      app: image-based-install-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Metrics scraping from openshift-monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver
+    - ports:
+        - protocol: TCP
+          port: 9443
+    # Image server - Ironic/BMC downloads ISOs (source IPs vary)
+    - ports:
+        - protocol: TCP
+          port: 8000
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API and spoke cluster API servers (dynamic IPs)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    # HTTPS egress (registries, external services)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- image-based-install-operator-networkpolicy.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manifests/bundle-overrides/csv-patch.yaml
+++ b/config/manifests/bundle-overrides/csv-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: image-based-install-operator.v0.0.1
+  namespace: placeholder
+  annotations:
+    createdAt: ""

--- a/config/manifests/bundle-overrides/kustomization.yaml
+++ b/config/manifests/bundle-overrides/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - csv.yaml
+patches:
+  - path: csv-patch.yaml


### PR DESCRIPTION
## Summary

- Adds a `NetworkPolicy` for the `image-based-install-operator` pod, following the ACM 5.0 DDR pattern (Create-Once + Operand Ownership)
- Restricts ingress to only the ports the operator listens on (8080 metrics, 9443 webhook, 8000 image server)
- Restricts egress to DNS, Kubernetes API, spoke cluster APIs (port 6443), and HTTPS (port 443)

## NetworkPolicy Details

**Ingress:**
- Same-namespace traffic (podSelector: {})
- OpenShift router → port 8000 (image server)
- Monitoring → port 8080 (metrics, exposed via ServiceMonitor on OCP)
- Any → port 9443 (webhook, called by kube-apiserver)
- Any → port 8000 (image server, called by Ironic/BMC)

**Egress:**
- DNS (openshift-dns, port 5353)
- Kubernetes API (port 6443)
- Spoke cluster API servers (0.0.0.0/0, port 6443)
- HTTPS (0.0.0.0/0, port 443, excluding AWS metadata)

## Test plan

- [x] Deploy NetworkPolicy on cluster with IBIO installed
- [x] Verify IBIO pod remains healthy (no restarts, no network errors)
- [x] Verify webhook (port 9443) responds from inside and outside namespace
- [x] Verify image server (port 8000) responds from inside and outside namespace
- [x] Verify random ports are blocked from inside and outside namespace
- [x] Verify egress to DNS and Kubernetes API works
- [ ] Verify metrics endpoint (port 8080) is scrapable via ServiceMonitor on OCP
- [ ] Run end-to-end image-based installation flow on OCP

## Test results (kind + Calico)

```
=== SUMMARY: 13 passed, 0 failed ===

Ingress allowed:  9443 (webhook), 8000 (image server), 8081 (health) ✓
Ingress blocked:  random ports denied from inside and outside namespace ✓
Cross-namespace:  8000 and 9443 reachable from default namespace ✓
Egress:           DNS resolution and Kubernetes API reachable ✓
Pod health:       running, all containers ready, no restarts, no network errors ✓
```

Note: metrics port 8080 binds to localhost in the manager — reachable via ServiceMonitor/Service on OCP, not via pod IP directly.

## Related

- Jira: [ACM-31164](https://redhat.atlassian.net/browse/ACM-31164)
- Also resolves: [ACM-37746](https://redhat.atlassian.net/browse/ACM-37746), [ACM-36702](https://redhat.atlassian.net/browse/ACM-36702)
- Epic: [ACM-31152](https://redhat.atlassian.net/browse/ACM-31152) (network policies for all ACM components)
- DDR: ACM-DDR-XXX (Enablement for NetworkPolicies by ACM Operators)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network security policies for the operator.
  * Allowed required DNS, Kubernetes API, HTTPS, monitoring, and operator communication traffic.
* **Chores**
  * Updated bundle generation and validation to include the network policy.
  * Added bundle configuration for consistent CSV metadata.
  * Cleared the generated CSV creation timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->