### PR TITLE
ACM-38238: Assisted-installer repos: Set Up Set up Renovate configuration to automatically create Hive API Synchronization PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,11 +19,29 @@
     "prConcurrentLimit": 0,
     "enabledManagers": [
         "custom.regex",
-        "tekton"
+        "tekton",
+        "gomod"
     ],
     "tekton": {
         "managerFilePatterns": [
             "/^.tekton/*/"
+        ]
+    },
+    "gomod": {
+        "postUpdateOptions": [
+            "gomodUpdateImportPaths",
+            "gomodTidy"
+        ],
+        "packageRules": [
+            {
+                "matchManagers": [
+                    "gomod"
+                ],
+                "matchDepTypes": [
+                    "indirect"
+                ],
+                "enabled": false
+            }
         ]
     },
     "customManagers": [
@@ -72,6 +90,26 @@
                 "registry.access.redhat.com/ubi9/ubi-minimal"
             ],
             "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "github.com/openshift/hive/apis"
+            ],
+            "groupName": "Hive API Synchronization",
+            "addLabels": [
+                "hive-api",
+                "api-sync"
+            ],
+            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
Set up Renovate configuration to automatically create Hive API Synchronization PRs.

Adds gomod to enabledManagers with postUpdateOptions (gomodUpdateImportPaths, gomodTidy), disables all gomod updates via packageRules, and enables only github.com/openshift/hive/apis.

Re-applies changes that were reverted by ACM-33186. Renovate issue is now resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management for Go modules.
  * Disabled indirect Go module updates by default.
  * Enabled targeted synchronization for Hive API dependencies.
  * Added automatic import-path updates and module cleanup after dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->