### PR TITLE
MGMT-24938: (IBIO) Upgrade operator-sdk from v1.30.0 to v1.42.3 (kubebuilder v3→v4 migration)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.42.3
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/PROJECT
+++ b/PROJECT
@@ -4,7 +4,7 @@
 # More info: https://book.kubebuilder.io/reference/project-config.html
 domain: openshift.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=image-based-install-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.30.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/image-based-install-operator.clusterserviceversion.yaml
@@ -36,9 +36,9 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-26T07:25:00Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.30.0
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    createdAt: "2026-07-29T12:29:20Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: image-based-install-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: image-based-install-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.30.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - bases/extensions.hive.openshift.io_imageclusterinstalls.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/hive_contract_label.yaml
+patches:
+- path: patches/hive_contract_label.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,7 +1,7 @@
 # Adds namespace to all resources.
 namespace: image-based-install-operator
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
## Summary

Upgrade operator-sdk from v1.30.0 to v1.42.3 and migrate the project layout from `go.kubebuilder.io/v3` to `go.kubebuilder.io/v4`.

The older operator-sdk (v1.30.0) depends on operator-registry v1.28.0 which doesn't support `NetworkPolicy` as a valid OLM bundle resource type — `operator-sdk bundle validate` rejects it. The new version (v1.42.3) depends on operator-registry v1.59.0 which supports it.

## Changes

- `PROJECT`: layout `go.kubebuilder.io/v3` → `go.kubebuilder.io/v4`
- `Makefile`: `OPERATOR_SDK_VERSION` `v1.30.0` → `v1.42.3`
- `config/default/kustomization.yaml`: `bases:` → `resources:` (deprecated kustomize syntax)
- `config/crd/kustomization.yaml`: `patchesStrategicMerge:` → `patches:` with `path:` key
- `config/scorecard/kustomization.yaml`: `patchesJson6902:` → `patches:`
- `bundle/`: regenerated metadata with updated builder/layout labels

No Go code changes. No runtime behavior changes. No Dockerfile changes. Tooling-only upgrade.

Migration guide: https://book.kubebuilder.io/migration/v3vsv4

## Related

- Jira: [MGMT-24938](https://redhat.atlassian.net/browse/MGMT-24938)
- Unblocks: [ACM-31164](https://redhat.atlassian.net/browse/ACM-31164) (NetworkPolicy in OLM bundle)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated project scaffolding and deployment metadata to newer Operator SDK and Kubebuilder versions.
  * Modernized Kustomize configuration for current patch and resource conventions.
  * Default deployments now consistently target the `image-based-install-operator` namespace.

* **Deployment**
  * Updated bundle and installation metadata to reflect the latest build tooling and project layout.
  * Refreshed the generated build timestamp in the installation manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->